### PR TITLE
perf: run HttpDriver outside of NgZone

### DIFF
--- a/projects/ngworker/lumberjack/src/lib/log-drivers/http-driver/http-driver.module.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/http-driver/http-driver.module.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule, NgZone } from '@angular/core';
 
 import { LogDriverToken } from '../log-driver';
 
@@ -7,8 +7,8 @@ import { HttpDriverConfig, HttpDriverConfigToken } from './http-driver.config';
 import { HttpDriver } from './http.driver';
 
 // factory functions need to extracted and exported for AOT
-export function httpDriverFactory(httpClient: HttpClient, config: HttpDriverConfig): HttpDriver {
-  return new HttpDriver(httpClient, config);
+export function httpDriverFactory(httpClient: HttpClient, config: HttpDriverConfig, ngZone: NgZone): HttpDriver {
+  return new HttpDriver(httpClient, config, ngZone);
 }
 
 @NgModule()
@@ -21,7 +21,7 @@ export class HttpDriverModule {
         {
           provide: LogDriverToken,
           useFactory: httpDriverFactory,
-          deps: [HttpClient, HttpDriverConfigToken],
+          deps: [HttpClient, HttpDriverConfigToken, NgZone],
           multi: true,
         },
       ],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Performance improvements
```

## What is the current behavior?

Sending a log wagon to the server triggers change detection for the Angular application even though it will not affect the UI state in any way.

Issue Number: N/A

## What is the new behavior?

HTTP calls made by the `HttpDriver` are run outside of the Angular zone.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm unsure what to do about the docs using `HttpDriver` as an example. This and other PRs @NachoVazquez and I discussed are going to change this class a lot. The code will become more complex.