### PR TITLE
fix: send log wagon from all log methods

### DIFF
--- a/projects/ngworker/lumberjack/src/lib/log-drivers/http-driver/http.driver.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/http-driver/http.driver.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { NgZone } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { Observable, of, Subject } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
 import { LumberjackLogLevel } from '../../lumberjack-log-levels';
@@ -27,16 +27,16 @@ export class HttpDriver implements LogDriver {
     return this.log(logEntry, LumberjackLogLevel.Info);
   }
 
-  logDebug(logEntry: string): void {
-    this.log(logEntry, LumberjackLogLevel.Debug);
+  logDebug(logEntry: string): Observable<void> {
+    return this.log(logEntry, LumberjackLogLevel.Debug);
   }
 
-  logError(logEntry: string): void {
-    this.log(logEntry, LumberjackLogLevel.Error);
+  logError(logEntry: string): Observable<void> {
+    return this.log(logEntry, LumberjackLogLevel.Error);
   }
 
-  logWarning(logEntry: string): void {
-    this.log(logEntry, LumberjackLogLevel.Warning);
+  logWarning(logEntry: string): Observable<void> {
+    return this.log(logEntry, LumberjackLogLevel.Warning);
   }
 
   private log(logEntry: string, logLevel: LumberjackLogLevel): Observable<void> {
@@ -46,6 +46,8 @@ export class HttpDriver implements LogDriver {
 
     if (this.logWagon.length >= logWagonSize) {
       return this.sendLogPackage().pipe(tap(() => (this.logWagon = [])));
+    } else {
+      of();
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1. An HTTP call is only made when using `HttpDriver#logInfo`.
1. An observable is not returned from the private `HttpDriver#log` method until the log wagon is full.

Issue Number: N/A

## What is the new behavior?

1. An HTTP call is only made when using all `HttpDriver#log*` methods.
1. An observable is always returned from the private `HttpDriver#log` method.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This is technically a breaking change as the public API of `HttpDriver` log methods changes. But we should be consistent across the different `log*` methods.

I don't think a logging method should return an observable. There are currently race conditions because of mutable state in the `logWagon` property, so we need to change this implementation before we can make the log methods synchronous.