### PR TITLE
fix: 🐛 make log signature not to support promise or observable

### DIFF
--- a/projects/ngworker/lumberjack/src/lib/log-drivers/http-driver/http.driver.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/http-driver/http.driver.ts
@@ -23,20 +23,20 @@ export class HttpDriver implements LogDriver {
 
   constructor(private http: HttpClient, public config: HttpDriverConfig, private ngZone: NgZone) {}
 
-  logInfo(logEntry: string): Observable<void> {
-    return this.log(logEntry, LumberjackLogLevel.Info);
+  logInfo(logEntry: string): void {
+    this.log(logEntry, LumberjackLogLevel.Info).subscribe();
   }
 
-  logDebug(logEntry: string): Observable<void> {
-    return this.log(logEntry, LumberjackLogLevel.Debug);
+  logDebug(logEntry: string): void {
+    this.log(logEntry, LumberjackLogLevel.Debug).subscribe();
   }
 
-  logError(logEntry: string): Observable<void> {
-    return this.log(logEntry, LumberjackLogLevel.Error);
+  logError(logEntry: string): void {
+    this.log(logEntry, LumberjackLogLevel.Error).subscribe();
   }
 
-  logWarning(logEntry: string): Observable<void> {
-    return this.log(logEntry, LumberjackLogLevel.Warning);
+  logWarning(logEntry: string): void {
+    this.log(logEntry, LumberjackLogLevel.Warning).subscribe();
   }
 
   private log(logEntry: string, logLevel: LumberjackLogLevel): Observable<void> {

--- a/projects/ngworker/lumberjack/src/lib/log-drivers/log-driver.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/log-driver.ts
@@ -7,8 +7,8 @@ export const LogDriverToken: InjectionToken<LogDriver> = new InjectionToken('__L
 
 export interface LogDriver {
   config: LogDriverConfig;
-  logInfo(logEntry: string): void | Promise<void> | Observable<void>;
-  logDebug(logEntry: string): void | Promise<void> | Observable<void>;
-  logError(logEntry: string): void | Promise<void> | Observable<void>;
-  logWarning(logEntry: string): void | Promise<void> | Observable<void>;
+  logInfo(logEntry: string): void;
+  logDebug(logEntry: string): void;
+  logError(logEntry: string): void;
+  logWarning(logEntry: string): void;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,13 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Lumberjack</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Lumberjack</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <ngworker-root></ngworker-root>
+  </body>
 </html>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

log-* methods from `LogDriver` interface can return `Observable` and `Promise`. This behavior is not desired since the `LumberjackService` cannot determine how to handle different scenarios.

Issue Number: N/A

## What is the new behavior?

Make log-* just to return void.

## Does this PR introduce a breaking change?

```
[ x ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Any third party logger returning an observable or a promise from its log-* methods will suffer from this change since such behavior is not longer supported.

Fix: subscribe to Observables or handle Promise inside log-* methods

## Other information
