### PR TITLE
fix: use valid default config in ConsoleDriverModule.forRoot

### DIFF
--- a/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.spec.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.spec.ts
@@ -1,0 +1,94 @@
+import { Type } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { defaultLogDriverConfig, LogDriverConfig } from '../../configs/log-driver.config';
+import { LumberjackLogLevel } from '../../lumberjack-log-levels';
+import { LumberjackModule } from '../../lumberjack.module';
+import { LogDriver, LogDriverToken } from '../log-driver';
+
+import { ConsoleDriverModule } from './console-driver.module';
+import { ConsoleDriver } from './console.driver';
+
+const createConsoleDriver = ({
+  config,
+  isLumberjackModuleImportedFirst = true,
+}: {
+  config?: LogDriverConfig;
+  isLumberjackModuleImportedFirst?: boolean;
+} = {}) => {
+  TestBed.configureTestingModule({
+    imports: [
+      isLumberjackModuleImportedFirst ? LumberjackModule.forRoot() : [],
+      ConsoleDriverModule.forRoot(config),
+      isLumberjackModuleImportedFirst ? [] : LumberjackModule.forRoot(),
+    ],
+  });
+
+  const [consoleDriver] = (TestBed.inject(LogDriverToken) as unknown) as LogDriver[];
+
+  return consoleDriver;
+};
+
+const expectNgModuleToBeImported = <TModule>(ngModuleType: Type<TModule>) => {
+  let ngModule: TModule | undefined;
+
+  expect(() => {
+    ngModule = TestBed.inject(ngModuleType);
+  })
+    .withContext(`${ngModuleType.name} has not been imported`)
+    .not.toThrowError(new RegExp(`NullInjectorError.*${ngModuleType.name}`));
+
+  expect(ngModule).toBeInstanceOf(ngModuleType);
+};
+
+describe(ConsoleDriverModule.name, () => {
+  it(`can be imported without using the ${ConsoleDriverModule.forRoot.name} method`, () => {
+    TestBed.configureTestingModule({
+      imports: [ConsoleDriverModule],
+    });
+
+    expectNgModuleToBeImported(ConsoleDriverModule);
+  });
+
+  describe(ConsoleDriverModule.forRoot.name, () => {
+    it('provides the console driver', () => {
+      const consoleDriver = createConsoleDriver();
+
+      expect(consoleDriver).toBeInstanceOf(ConsoleDriver);
+    });
+
+    it('registers the specified log driver configuration', () => {
+      const expectedConfig: LogDriverConfig = {
+        levels: [LumberjackLogLevel.Error],
+      };
+
+      const consoleDriver = createConsoleDriver({ config: expectedConfig });
+
+      const actualConfig = consoleDriver.config;
+      expect(actualConfig).toEqual(expectedConfig);
+    });
+
+    it('registers a default configuration if none is specified', () => {
+      const expectedConfig = defaultLogDriverConfig;
+
+      const consoleDriver = createConsoleDriver();
+
+      const actualConfig = consoleDriver.config;
+      expect(actualConfig).toEqual(expectedConfig);
+    });
+
+    it('does not register the specified log driver configuration when the lumberjack module is imported after the console driver module', () => {
+      const expectedConfig: LogDriverConfig = {
+        levels: [LumberjackLogLevel.Debug],
+      };
+
+      const consoleDriver = createConsoleDriver({
+        config: expectedConfig,
+        isLumberjackModuleImportedFirst: false,
+      });
+
+      const actualConfig = consoleDriver.config;
+      expect(actualConfig).not.toEqual(expectedConfig);
+    });
+  });
+});

--- a/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.ts
@@ -1,6 +1,6 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
-import { LogDriverConfig, LogDriverConfigToken } from '../../configs/log-driver.config';
+import { defaultLogDriverConfig, LogDriverConfig, LogDriverConfigToken } from '../../configs/log-driver.config';
 import { LogDriverToken } from '../log-driver';
 
 import { ConsoleDriver } from './console.driver';
@@ -11,7 +11,7 @@ export function consoleFactory(config: LogDriverConfig): ConsoleDriver {
 
 @NgModule()
 export class ConsoleDriverModule {
-  static forRoot(config: LogDriverConfig = {}): ModuleWithProviders<ConsoleDriverModule> {
+  static forRoot(config: LogDriverConfig = defaultLogDriverConfig): ModuleWithProviders<ConsoleDriverModule> {
     return {
       ngModule: ConsoleDriverModule,
       providers: [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

An empty object is used as the default `LogDriverConfig` when no configuration is passed to the `ConsoleDriverModule.forRoot` method. An empty object does not property implement the `LogDriverConfig` interface as a `levels` property is required even though it can be `undefined`.

Issue Number: N/A

## What is the new behavior?
The `defaultLogDriverConfig` is used when no configuration is passed to the `ConsoleDriverModule.forRoot` method.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
A test suite for the `ConsoleDriverModule` was added.