### PR TITLE
feat: guard against importing ConsoleDriverModule without forRoot

### DIFF
--- a/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver-root.module.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver-root.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+
+import { LogDriverToken } from '../log-driver';
+
+import { ConsoleDriver } from './console.driver';
+
+@NgModule({
+  providers: [
+    {
+      provide: LogDriverToken,
+      useClass: ConsoleDriver,
+      multi: true,
+    },
+  ],
+})
+export class ConsoleDriverRootModule {}

--- a/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.spec.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.spec.ts
@@ -29,25 +29,23 @@ const createConsoleDriver = ({
   return consoleDriver;
 };
 
-const expectNgModuleToBeImported = <TModule>(ngModuleType: Type<TModule>) => {
+const expectNgModuleToBeGuarded = <TModule>(ngModuleType: Type<TModule>) => {
   let ngModule: TModule | undefined;
+
+  TestBed.configureTestingModule({
+    imports: [ngModuleType],
+  });
 
   expect(() => {
     ngModule = TestBed.inject(ngModuleType);
   })
-    .withContext(`${ngModuleType.name} has not been imported`)
-    .not.toThrowError(new RegExp(`NullInjectorError.*${ngModuleType.name}`));
-
-  expect(ngModule).toBeInstanceOf(ngModuleType);
+    .withContext(`${ngModuleType.name} must guard against being imported directly`)
+    .toThrow();
 };
 
 describe(ConsoleDriverModule.name, () => {
-  it(`can be imported without using the ${ConsoleDriverModule.forRoot.name} method`, () => {
-    TestBed.configureTestingModule({
-      imports: [ConsoleDriverModule],
-    });
-
-    expectNgModuleToBeImported(ConsoleDriverModule);
+  it(`cannot be imported without using the ${ConsoleDriverModule.forRoot.name} method`, () => {
+    expectNgModuleToBeGuarded(ConsoleDriverModule);
   });
 
   describe(ConsoleDriverModule.forRoot.name, () => {

--- a/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.ts
@@ -1,23 +1,19 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { defaultLogDriverConfig, LogDriverConfig, LogDriverConfigToken } from '../../configs/log-driver.config';
-import { LogDriverToken } from '../log-driver';
 
-import { ConsoleDriver } from './console.driver';
+import { ConsoleDriverRootModule } from './console-driver-root.module';
 
 @NgModule()
 export class ConsoleDriverModule {
-  static forRoot(config: LogDriverConfig = defaultLogDriverConfig): ModuleWithProviders<ConsoleDriverModule> {
+  static forRoot(config: LogDriverConfig = defaultLogDriverConfig): ModuleWithProviders<ConsoleDriverRootModule> {
     return {
-      ngModule: ConsoleDriverModule,
-      providers: [
-        { provide: LogDriverConfigToken, useValue: config },
-        {
-          provide: LogDriverToken,
-          useClass: ConsoleDriver,
-          multi: true,
-        },
-      ],
+      ngModule: ConsoleDriverRootModule,
+      providers: [{ provide: LogDriverConfigToken, useValue: config }],
     };
+  }
+
+  constructor() {
+    throw new Error('Do not import ConsoleDriverModule directly. Use ConsoleDriverModule.forRoot.');
   }
 }

--- a/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console-driver.module.ts
@@ -5,10 +5,6 @@ import { LogDriverToken } from '../log-driver';
 
 import { ConsoleDriver } from './console.driver';
 
-export function consoleFactory(config: LogDriverConfig): ConsoleDriver {
-  return new ConsoleDriver(config);
-}
-
 @NgModule()
 export class ConsoleDriverModule {
   static forRoot(config: LogDriverConfig = defaultLogDriverConfig): ModuleWithProviders<ConsoleDriverModule> {
@@ -18,9 +14,8 @@ export class ConsoleDriverModule {
         { provide: LogDriverConfigToken, useValue: config },
         {
           provide: LogDriverToken,
-          useFactory: consoleFactory,
+          useClass: ConsoleDriver,
           multi: true,
-          deps: [LogDriverConfigToken],
         },
       ],
     };

--- a/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console.driver.ts
+++ b/projects/ngworker/lumberjack/src/lib/log-drivers/console-driver/console.driver.ts
@@ -1,8 +1,11 @@
-import { LogDriverConfig } from '../../configs/log-driver.config';
+import { Inject, Injectable } from '@angular/core';
+
+import { LogDriverConfig, LogDriverConfigToken } from '../../configs/log-driver.config';
 import { LogDriver } from '../log-driver';
 
+@Injectable()
 export class ConsoleDriver implements LogDriver {
-  constructor(public config: LogDriverConfig) {}
+  constructor(@Inject(LogDriverConfigToken) public config: LogDriverConfig) {}
 
   logInfo(logEntry: string): void {
     console.info(logEntry);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`ConsoleDriverModule` can be imported directly which does not currently make sense.

Issue Number: N/A

## What is the new behavior?
Consumers must import using `ConsoleDriverModule.forRoot`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Rebase after merging #11 as its commits are included in this one to use the test suite for `ConsoleDriverModule` while refactoring and adding this feature.