### PR TITLE
refactor: remove Inject decorator from root module guard

### DIFF
--- a/libs/ngworker/lumberjack/console-driver/src/console-driver-root.module.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/console-driver-root.module.spec.ts
@@ -6,4 +6,8 @@ describe(ConsoleDriverRootModule.name, () => {
 
     expect(() => new ConsoleDriverRootModule(rootInjectorInstance)).toThrowError(/multiple injectors/);
   });
+
+  it('does not guard the first injector that registers it', () => {
+    expect(() => new ConsoleDriverRootModule()).not.toThrow();
+  });
 });

--- a/libs/ngworker/lumberjack/console-driver/src/console-driver-root.module.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/console-driver-root.module.ts
@@ -15,7 +15,12 @@ import { ConsoleDriver } from './console.driver';
 })
 export class ConsoleDriverRootModule {
   constructor(
-    @Optional() @SkipSelf() @Inject(ConsoleDriverRootModule) maybeNgModuleFromParentInjector?: ConsoleDriverRootModule
+    // tslint:disable: no-any no-null-keyword
+    @Optional()
+    @SkipSelf()
+    @Inject(ConsoleDriverRootModule)
+    maybeNgModuleFromParentInjector: ConsoleDriverRootModule = null as any
+    // tslint:enable: no-any no-null-keyword
   ) {
     if (maybeNgModuleFromParentInjector) {
       throw new Error(

--- a/libs/ngworker/lumberjack/http-driver/src/http-driver-root.module.spec.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/http-driver-root.module.spec.ts
@@ -8,10 +8,6 @@ describe(HttpDriverRootModule.name, () => {
   });
 
   it('does not guard the first injector that registers it', () => {
-    // tslint:disable-next-line: no-null-keyword
-    const optionalAngularDependency = null;
-
-    // tslint:disable-next-line: no-any
-    expect(() => new HttpDriverRootModule(optionalAngularDependency as any)).not.toThrow();
+    expect(() => new HttpDriverRootModule()).not.toThrow();
   });
 });

--- a/libs/ngworker/lumberjack/http-driver/src/http-driver-root.module.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/http-driver-root.module.ts
@@ -33,7 +33,12 @@ export function httpDriverFactory(
 })
 export class HttpDriverRootModule {
   constructor(
-    @Optional() @SkipSelf() @Inject(HttpDriverRootModule) maybeNgModuleFromParentInjector?: HttpDriverRootModule
+    // tslint:disable: no-any no-null-keyword
+    @Optional()
+    @SkipSelf()
+    @Inject(HttpDriverRootModule)
+    maybeNgModuleFromParentInjector: HttpDriverRootModule = null as any
+    // tslint:enable: no-any no-null-keyword
   ) {
     if (maybeNgModuleFromParentInjector) {
       throw new Error(

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.spec.ts
@@ -6,4 +6,8 @@ describe(LumberjackRootModule.name, () => {
 
     expect(() => new LumberjackRootModule(rootInjectorInstance)).toThrowError(/multiple injectors/);
   });
+
+  it('does not guard the first injector that registers it', () => {
+    expect(() => new LumberjackRootModule()).not.toThrow();
+  });
 });

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.ts
@@ -12,7 +12,12 @@ import { defaultLogDriverConfig, LogDriverConfigToken } from './configs/log-driv
 })
 export class LumberjackRootModule {
   constructor(
-    @Optional() @SkipSelf() @Inject(LumberjackRootModule) maybeNgModuleFromParentInjector?: LumberjackRootModule
+    // tslint:disable: no-any no-null-keyword
+    @Optional()
+    @SkipSelf()
+    @Inject(LumberjackRootModule)
+    maybeNgModuleFromParentInjector: LumberjackRootModule = null as any
+    // tslint:enable: no-any no-null-keyword
   ) {
     if (maybeNgModuleFromParentInjector) {
       throw new Error(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

An issue in Angular 9.0 keeps us from marking the injected root module as optional or possibly null.

Issue Number: N/A

## What is the new behavior?

The injected root module as null to make it more explicit that Angular DI passes null for optional dependencies.

Additionally, tests have been simplified.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
https://github.com/ngworker/lumberjack/pull/30/files