### PR TITLE
feat: add timestamp to log entries

### DIFF
--- a/apps/lumberjack-app-e2e/src/app.e2e-spec.ts
+++ b/apps/lumberjack-app-e2e/src/app.e2e-spec.ts
@@ -19,9 +19,7 @@ describe('workspace-project App', () => {
     const logs = await browser.manage().logs().get(logging.Type.BROWSER);
     const filteredLogs = logs.filter(
       (log) =>
-        !log.message.includes('[AppComponent]') &&
-        !log.message.includes('/api/logs') &&
-        !log.message.includes('polyfills.js')
+        !log.message.includes('[App]') && !log.message.includes('/api/logs') && !log.message.includes('polyfills.js')
     );
 
     await expect(filteredLogs).not.toContain(

--- a/apps/lumberjack-app/src/app/app-logger.service.ts
+++ b/apps/lumberjack-app/src/app/app-logger.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+
+import { LumberjackLogger } from '@ngworker/lumberjack';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AppLogger extends LumberjackLogger {
+  private static logContext = 'App';
+
+  forestOnFire = this.createErrorLogger('The forest is on fire', AppLogger.logContext);
+
+  helloForest = this.createInfoLogger('HelloForest', AppLogger.logContext);
+}

--- a/apps/lumberjack-app/src/app/app-logger.service.ts
+++ b/apps/lumberjack-app/src/app/app-logger.service.ts
@@ -1,12 +1,16 @@
 import { Injectable } from '@angular/core';
 
-import { LumberjackLogger } from '@ngworker/lumberjack';
+import { LumberjackLogger, LumberjackService, LumberjackTimeService } from '@ngworker/lumberjack';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AppLogger extends LumberjackLogger {
   private static logContext = 'App';
+
+  constructor(lumberjack: LumberjackService, time: LumberjackTimeService) {
+    super(lumberjack, time);
+  }
 
   forestOnFire = this.createErrorLogger('The forest is on fire', AppLogger.logContext);
 

--- a/apps/lumberjack-app/src/app/app.component.ts
+++ b/apps/lumberjack-app/src/app/app.component.ts
@@ -1,20 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
-import { LumberjackService } from '@ngworker/lumberjack';
-
-import { ForestOnFire } from './log-types/error-logs';
-import { HelloForest } from './log-types/info-logs';
+import { AppLogger } from './app-logger.service';
 
 @Component({
   selector: 'ngworker-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'lumberjack';
 
-  constructor(private lumberjack: LumberjackService) {
-    this.lumberjack.log(HelloForest());
-    this.lumberjack.log(ForestOnFire());
+  constructor(private logger: AppLogger) {}
+
+  ngOnInit(): void {
+    this.logger.helloForest();
+    this.logger.forestOnFire();
   }
 }

--- a/libs/internal/test-util/src/index.ts
+++ b/libs/internal/test-util/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './lib/expect-ng-module-to-be-guarded';
+export * from './lib/logs/log-creators';
 export * from './lib/noop-driver/noop-driver.module';
 export * from './lib/noop-driver/noop.driver';
 export * from './lib/spy-driver/spy-driver.module';

--- a/libs/internal/test-util/src/lib/logs/log-creators.ts
+++ b/libs/internal/test-util/src/lib/logs/log-creators.ts
@@ -1,0 +1,18 @@
+import { LumberjackLogEntryLevel, LumberjackLogLevel, LumberjackTimeService } from '@ngworker/lumberjack';
+
+import { resolveDependency } from '../resolve-dependency';
+
+const createLog = (level: LumberjackLogEntryLevel, message = '', context = 'Test') => ({
+  context,
+  createdAt: resolveDependency(LumberjackTimeService).getUnixEpochTicks(),
+  level,
+  message,
+});
+export const createDebugLog = (message?: string, context?: string) =>
+  createLog(LumberjackLogLevel.Debug, message, context);
+export const createErrorLog = (message?: string, context?: string) =>
+  createLog(LumberjackLogLevel.Error, message, context);
+export const createInfoLog = (message?: string, context?: string) =>
+  createLog(LumberjackLogLevel.Info, message, context);
+export const createWarningLog = (message?: string, context?: string) =>
+  createLog(LumberjackLogLevel.Warning, message, context);

--- a/libs/ngworker/lumberjack/src/index.ts
+++ b/libs/ngworker/lumberjack/src/index.ts
@@ -3,9 +3,7 @@
  */
 
 export * from './lib/configs';
-export * from './lib/log-creator';
 export * from './lib/log-drivers';
-export * from './lib/log-types';
 export * from './lib/lumberjack-log';
 export * from './lib/lumberjack-log-levels';
 export * from './lib/lumberjack.module';

--- a/libs/ngworker/lumberjack/src/index.ts
+++ b/libs/ngworker/lumberjack/src/index.ts
@@ -6,6 +6,7 @@ export * from './lib/configs';
 export * from './lib/log-drivers';
 export * from './lib/lumberjack-log';
 export * from './lib/lumberjack-log-levels';
+export * from './lib/lumberjack-logger.service';
 export * from './lib/lumberjack.module';
 export * from './lib/lumberjack.service';
 export * from './lib/time';

--- a/libs/ngworker/lumberjack/src/index.ts
+++ b/libs/ngworker/lumberjack/src/index.ts
@@ -10,3 +10,4 @@ export * from './lib/lumberjack-log';
 export * from './lib/lumberjack-log-levels';
 export * from './lib/lumberjack.module';
 export * from './lib/lumberjack.service';
+export * from './lib/time';

--- a/libs/ngworker/lumberjack/src/lib/configs/default-log.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/default-log.config.ts
@@ -1,9 +1,0 @@
-import { LumberjackLog } from '../lumberjack-log';
-
-import { LumberjackLogConfig } from './lumberjack-log.config';
-
-export const defaultLogConfig: LumberjackLogConfig = {
-  format(logEntry: LumberjackLog): string {
-    return `${logEntry.level.toString()}  ${new Date().toISOString()}  [${logEntry.context}] ${logEntry.message}`;
-  },
-};

--- a/libs/ngworker/lumberjack/src/lib/configs/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/index.ts
@@ -1,3 +1,2 @@
-export * from './default-log.config';
 export * from './log-driver.config';
 export * from './lumberjack-log.config';

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
@@ -1,9 +1,22 @@
-import { InjectionToken } from '@angular/core';
+import { inject, InjectionToken } from '@angular/core';
 
 import { LumberjackLog } from '../lumberjack-log';
+import { LumberjackTimeService } from '../time';
 
 export const LumberjackLogConfigToken: InjectionToken<LumberjackLogConfig> = new InjectionToken(
-  '__LUMBERJACK_LOG_CONFIG__'
+  '__LUMBERJACK_LOG_CONFIG__',
+  {
+    factory: (): LumberjackLogConfig => {
+      const time = inject(LumberjackTimeService);
+
+      return {
+        format: (logEntry) =>
+          `${logEntry.level}  ${time.utcTimestampFor(time.getUnixEpochTicks())} [${logEntry.context}] ${
+            logEntry.message
+          }`,
+      };
+    },
+  }
 );
 
 export interface LumberjackLogConfig {

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
@@ -10,7 +10,7 @@ export const LumberjackLogConfigToken: InjectionToken<LumberjackLogConfig> = new
       const time = inject(LumberjackTimeService);
 
       return {
-        format: ({ context, level, message, timestamp }) =>
+        format: ({ context, level, message, createdAt: timestamp }) =>
           `${level}  ${time.utcTimestampFor(timestamp)} ${context ? `[${context}]` : ''} ${message}`,
       };
     },

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
@@ -10,10 +10,8 @@ export const LumberjackLogConfigToken: InjectionToken<LumberjackLogConfig> = new
       const time = inject(LumberjackTimeService);
 
       return {
-        format: (logEntry) =>
-          `${logEntry.level}  ${time.utcTimestampFor(time.getUnixEpochTicks())} [${logEntry.context}] ${
-            logEntry.message
-          }`,
+        format: ({ context, level, message, timestamp }) =>
+          `${level}  ${time.utcTimestampFor(timestamp)} ${context ? `[${context}]` : ''} ${message}`,
       };
     },
   }

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
@@ -10,7 +10,7 @@ export const LumberjackLogConfigToken: InjectionToken<LumberjackLogConfig> = new
       const time = inject(LumberjackTimeService);
 
       return {
-        format: ({ context, level, message, createdAt: timestamp }) =>
+        format: ({ context, createdAt: timestamp, level, message }) =>
           `${level}  ${time.utcTimestampFor(timestamp)} ${context ? `[${context}]` : ''} ${message}`,
       };
     },

--- a/libs/ngworker/lumberjack/src/lib/log-creator.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-creator.ts
@@ -1,7 +1,0 @@
-import { LumberjackLog } from './lumberjack-log';
-import { LumberjackLogEntryLevel } from './lumberjack-log-levels';
-
-// TODO(LayZeeDK): remove
-export function createLog(level: LumberjackLogEntryLevel, message: string, context?: string): () => LumberjackLog {
-  return () => ({ level, message, context, createdAt: 0 });
-}

--- a/libs/ngworker/lumberjack/src/lib/log-creator.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-creator.ts
@@ -1,6 +1,7 @@
 import { LumberjackLog } from './lumberjack-log';
 import { LumberjackLogEntryLevel } from './lumberjack-log-levels';
 
+// TODO(LayZeeDK): remove
 export function createLog(level: LumberjackLogEntryLevel, message: string, context?: string): () => LumberjackLog {
-  return () => ({ level, message, context });
+  return () => ({ level, message, context, timestamp: 0 });
 }

--- a/libs/ngworker/lumberjack/src/lib/log-creator.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-creator.ts
@@ -3,5 +3,5 @@ import { LumberjackLogEntryLevel } from './lumberjack-log-levels';
 
 // TODO(LayZeeDK): remove
 export function createLog(level: LumberjackLogEntryLevel, message: string, context?: string): () => LumberjackLog {
-  return () => ({ level, message, context, timestamp: 0 });
+  return () => ({ level, message, context, createdAt: 0 });
 }

--- a/libs/ngworker/lumberjack/src/lib/log-types/debug-logs/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-types/debug-logs/index.ts
@@ -1,7 +1,0 @@
-import { createLog } from '../../log-creator';
-import { LumberjackLog } from '../../lumberjack-log';
-import { LumberjackLogLevel } from '../../lumberjack-log-levels';
-
-export function createDebugLog(message: string, context: string = ''): () => LumberjackLog {
-  return createLog(LumberjackLogLevel.Debug, message, context);
-}

--- a/libs/ngworker/lumberjack/src/lib/log-types/error-logs/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-types/error-logs/index.ts
@@ -1,7 +1,0 @@
-import { createLog } from '../../log-creator';
-import { LumberjackLog } from '../../lumberjack-log';
-import { LumberjackLogLevel } from '../../lumberjack-log-levels';
-
-export function createErrorLog(message: string, context: string = ''): () => LumberjackLog {
-  return createLog(LumberjackLogLevel.Error, message, context);
-}

--- a/libs/ngworker/lumberjack/src/lib/log-types/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-types/index.ts
@@ -1,6 +1,0 @@
-export * from './debug-logs';
-export * from './error-logs';
-export * from './info-logs';
-export * from './warning-logs';
-
-export * from './lumberjack-logger.service';

--- a/libs/ngworker/lumberjack/src/lib/log-types/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-types/index.ts
@@ -1,4 +1,6 @@
+export * from './debug-logs';
 export * from './error-logs';
 export * from './info-logs';
 export * from './warning-logs';
-export * from './debug-logs';
+
+export * from './lumberjack-logger.service';

--- a/libs/ngworker/lumberjack/src/lib/log-types/info-logs/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-types/info-logs/index.ts
@@ -1,7 +1,0 @@
-import { createLog } from '../../log-creator';
-import { LumberjackLog } from '../../lumberjack-log';
-import { LumberjackLogLevel } from '../../lumberjack-log-levels';
-
-export function createInfoLog(message: string, context: string = ''): () => LumberjackLog {
-  return createLog(LumberjackLogLevel.Info, message, context);
-}

--- a/libs/ngworker/lumberjack/src/lib/log-types/lumberjack-logger.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-types/lumberjack-logger.service.ts
@@ -26,7 +26,7 @@ export abstract class LumberjackLogger {
 
   private createLogger(level: LumberjackLogEntryLevel, message: string, context: string = ''): () => void {
     return () => {
-      this.lumberjack.log({ context, level, message, timestamp: this.time.getUnixEpochTicks() });
+      this.lumberjack.log({ context, level, message, createdAt: this.time.getUnixEpochTicks() });
     };
   }
 }

--- a/libs/ngworker/lumberjack/src/lib/log-types/lumberjack-logger.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-types/lumberjack-logger.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+
+import { LumberjackLogEntryLevel, LumberjackLogLevel } from '../lumberjack-log-levels';
+import { LumberjackService } from '../lumberjack.service';
+import { LumberjackTimeService } from '../time';
+
+@Injectable({
+  providedIn: 'root',
+})
+export abstract class LumberjackLogger {
+  constructor(private lumberjack: LumberjackService, private time: LumberjackTimeService) {}
+
+  protected createDebugLogger(message: string, context: string = ''): () => void {
+    return this.createLogger(LumberjackLogLevel.Debug, message, context);
+  }
+
+  protected createErrorLogger(message: string, context: string = ''): () => void {
+    return this.createLogger(LumberjackLogLevel.Error, message, context);
+  }
+
+  protected createInfoLogger(message: string, context: string = ''): () => void {
+    return this.createLogger(LumberjackLogLevel.Info, message, context);
+  }
+
+  protected createWarningLogger(message: string, context: string = ''): () => void {
+    return this.createLogger(LumberjackLogLevel.Warning, message, context);
+  }
+
+  private createLogger(level: LumberjackLogEntryLevel, message: string, context: string = ''): () => void {
+    return () => {
+      this.lumberjack.log({ context, level, message, timestamp: this.time.getUnixEpochTicks() });
+    };
+  }
+}

--- a/libs/ngworker/lumberjack/src/lib/log-types/lumberjack-logger.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-types/lumberjack-logger.service.ts
@@ -4,9 +4,7 @@ import { LumberjackLogEntryLevel, LumberjackLogLevel } from '../lumberjack-log-l
 import { LumberjackService } from '../lumberjack.service';
 import { LumberjackTimeService } from '../time';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export abstract class LumberjackLogger {
   constructor(private lumberjack: LumberjackService, private time: LumberjackTimeService) {}
 

--- a/libs/ngworker/lumberjack/src/lib/log-types/warning-logs/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-types/warning-logs/index.ts
@@ -1,7 +1,0 @@
-import { createLog } from '../../log-creator';
-import { LumberjackLog } from '../../lumberjack-log';
-import { LumberjackLogLevel } from '../../lumberjack-log-levels';
-
-export function createWarningLog(message: string, context: string = ''): () => LumberjackLog {
-  return createLog(LumberjackLogLevel.Warning, message, context);
-}

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-log.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-log.ts
@@ -11,5 +11,5 @@ export interface LumberjackLog {
   /**
    * Unix epoch ticks (milliseconds).
    */
-  timestamp: number;
+  createdAt: number;
 }

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-log.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-log.ts
@@ -8,4 +8,8 @@ export interface LumberjackLog {
   level: LumberjackLogEntryLevel;
   message: string;
   context: string | undefined;
+  /**
+   * Unix epoch ticks (milliseconds).
+   */
+  timestamp: number;
 }

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-log.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-log.ts
@@ -1,15 +1,23 @@
 import { LumberjackLogEntryLevel } from './lumberjack-log-levels';
 
 /**
- * Represents a Lumberjack log.
- *
+ * A Lumberjack log entry
  */
 export interface LumberjackLog {
-  level: LumberjackLogEntryLevel;
-  message: string;
-  context: string | undefined;
   /**
-   * Unix epoch ticks (milliseconds).
+   * Context, for example domain, application, component, or service.
    */
-  createdAt: number;
+  readonly context?: string;
+  /**
+   * Unix epoch ticks (milliseconds) timestamp when log entry was created.
+   */
+  readonly createdAt: number;
+  /**
+   * Level of severity.
+   */
+  readonly level: LumberjackLogEntryLevel;
+  /**
+   * Log messsage, for example describing an event that happened.
+   */
+  readonly message: string;
 }

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-logger.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-logger.service.spec.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  createDebugLog,
+  createErrorLog,
+  createInfoLog,
+  createWarningLog,
+  resolveDependency,
+} from '@internal/test-util';
+
+import { LumberjackLogger } from './lumberjack-logger.service';
+import { LumberjackService } from './lumberjack.service';
+import { LumberjackTimeService } from './time';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TestLogger extends LumberjackLogger {
+  static context = 'Test';
+
+  debugLogger = this.createDebugLogger('', TestLogger.context);
+  errorLogger = this.createErrorLogger('', TestLogger.context);
+  infoLogger = this.createInfoLogger('', TestLogger.context);
+  warningLogger = this.createWarningLogger('', TestLogger.context);
+}
+
+const fakeDate = new Date('2020-02-02T02:02:02.000Z');
+
+describe(LumberjackLogger.name, () => {
+  beforeEach(() => {
+    lumberjackStub = jasmine.createSpyObj<LumberjackService>(LumberjackTimeService.name, ['log']);
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: LumberjackService, useValue: lumberjackStub }],
+    });
+
+    const fakeTime = resolveDependency(LumberjackTimeService);
+    spyOn(fakeTime, 'getUnixEpochTicks').and.returnValue(fakeDate.valueOf());
+    logger = resolveDependency(TestLogger);
+  });
+
+  let logger: TestLogger;
+  let lumberjackStub: jasmine.SpyObj<LumberjackService>;
+
+  it('can create a debug logger', () => {
+    logger.debugLogger();
+
+    expect(lumberjackStub.log).toHaveBeenCalledTimes(1);
+    expect(lumberjackStub.log).toHaveBeenCalledWith(createDebugLog());
+  });
+
+  it('can create an error logger', () => {
+    logger.errorLogger();
+
+    expect(lumberjackStub.log).toHaveBeenCalledTimes(1);
+    expect(lumberjackStub.log).toHaveBeenCalledWith(createErrorLog());
+  });
+
+  it('can create an info logger', () => {
+    logger.infoLogger();
+
+    expect(lumberjackStub.log).toHaveBeenCalledTimes(1);
+    expect(lumberjackStub.log).toHaveBeenCalledWith(createInfoLog());
+  });
+
+  it('can create a warning logger', () => {
+    logger.warningLogger();
+
+    expect(lumberjackStub.log).toHaveBeenCalledTimes(1);
+    expect(lumberjackStub.log).toHaveBeenCalledWith(createWarningLog());
+  });
+});

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-logger.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-logger.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 
-import { LumberjackLogEntryLevel, LumberjackLogLevel } from '../lumberjack-log-levels';
-import { LumberjackService } from '../lumberjack.service';
-import { LumberjackTimeService } from '../time';
+import { LumberjackLogEntryLevel, LumberjackLogLevel } from './lumberjack-log-levels';
+import { LumberjackService } from './lumberjack.service';
+import { LumberjackTimeService } from './time';
 
 @Injectable()
 export abstract class LumberjackLogger {

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-logger.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-logger.service.ts
@@ -8,25 +8,25 @@ import { LumberjackTimeService } from './time';
 export abstract class LumberjackLogger {
   constructor(private lumberjack: LumberjackService, private time: LumberjackTimeService) {}
 
-  protected createDebugLogger(message: string, context: string = ''): () => void {
+  protected createDebugLogger(message: string, context?: string): () => void {
     return this.createLogger(LumberjackLogLevel.Debug, message, context);
   }
 
-  protected createErrorLogger(message: string, context: string = ''): () => void {
+  protected createErrorLogger(message: string, context?: string): () => void {
     return this.createLogger(LumberjackLogLevel.Error, message, context);
   }
 
-  protected createInfoLogger(message: string, context: string = ''): () => void {
+  protected createInfoLogger(message: string, context?: string): () => void {
     return this.createLogger(LumberjackLogLevel.Info, message, context);
   }
 
-  protected createWarningLogger(message: string, context: string = ''): () => void {
+  protected createWarningLogger(message: string, context?: string): () => void {
     return this.createLogger(LumberjackLogLevel.Warning, message, context);
   }
 
-  private createLogger(level: LumberjackLogEntryLevel, message: string, context: string = ''): () => void {
+  private createLogger(level: LumberjackLogEntryLevel, message: string, context?: string): () => void {
     return () => {
-      this.lumberjack.log({ context, level, message, createdAt: this.time.getUnixEpochTicks() });
+      this.lumberjack.log({ context, createdAt: this.time.getUnixEpochTicks(), level, message });
     };
   }
 }

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
@@ -2,13 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { expectNgModuleToBeGuarded, resolveDependency } from '@internal/test-util';
 
-import {
-  defaultLogConfig,
-  defaultLogDriverConfig,
-  LogDriverConfigToken,
-  LumberjackLogConfig,
-  LumberjackLogConfigToken,
-} from './configs';
+import { defaultLogDriverConfig, LogDriverConfigToken, LumberjackLogConfig, LumberjackLogConfigToken } from './configs';
 import { LumberjackModule } from './lumberjack.module';
 
 describe(LumberjackModule.name, () => {
@@ -36,7 +30,9 @@ describe(LumberjackModule.name, () => {
       });
 
       const actualConfig = resolveDependency(LumberjackLogConfigToken);
-      expect(actualConfig).toEqual(defaultLogConfig);
+      expect(actualConfig).toEqual({
+        format: jasmine.any(Function),
+      });
     });
 
     it('provides a default log driver configuration', () => {

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.module.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.module.ts
@@ -1,20 +1,14 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
-import { defaultLogConfig } from './configs/default-log.config';
 import { LumberjackLogConfig, LumberjackLogConfigToken } from './configs/lumberjack-log.config';
 import { LumberjackRootModule } from './lumberjack-root.module';
 
 @NgModule()
 export class LumberjackModule {
-  static forRoot(config: LumberjackLogConfig = defaultLogConfig): ModuleWithProviders<LumberjackRootModule> {
+  static forRoot(config?: LumberjackLogConfig): ModuleWithProviders<LumberjackRootModule> {
     return {
       ngModule: LumberjackRootModule,
-      providers: [
-        {
-          provide: LumberjackLogConfigToken,
-          useValue: config,
-        },
-      ],
+      providers: (config && [{ provide: LumberjackLogConfigToken, useValue: config }]) || [],
     };
   }
 

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.service.spec.ts
@@ -1,16 +1,25 @@
 import { StaticProvider } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { NoopDriver, NoopDriverModule, resolveDependency, SpyDriver, SpyDriverModule } from '@internal/test-util';
+import {
+  createDebugLog,
+  createErrorLog,
+  createInfoLog,
+  createWarningLog,
+  NoopDriver,
+  NoopDriverModule,
+  resolveDependency,
+  SpyDriver,
+  SpyDriverModule,
+} from '@internal/test-util';
 
 import { ConsoleDriverModule } from '../../console-driver/src/console-driver.module';
 
 import { LogDriverConfig, LogDriverConfigToken } from './configs';
 import { LogDriver, LogDriverToken } from './log-drivers';
-import { LumberjackLogEntryLevel, LumberjackLogLevel } from './lumberjack-log-levels';
+import { LumberjackLogLevel } from './lumberjack-log-levels';
 import { LumberjackModule } from './lumberjack.module';
 import { LumberjackService } from './lumberjack.service';
-import { LumberjackTimeService } from './time';
 
 const noLogsConfig: LogDriverConfig = {
   levels: [],
@@ -34,28 +43,7 @@ const verboseLoggingProvider: StaticProvider = {
   useValue: verboseLoggingConfig,
 };
 
-const createLog = (level: LumberjackLogEntryLevel, message = '') => ({
-  context: 'Test',
-  createdAt: resolveDependency(LumberjackTimeService).getUnixEpochTicks(),
-  level,
-  message,
-});
-const createDebugLog = (message = '') => createLog(LumberjackLogLevel.Debug, message);
-const createErrorLog = (message = '') => createLog(LumberjackLogLevel.Error, message);
-const createInfoLog = (message = '') => createLog(LumberjackLogLevel.Info, message);
-const createWarningLog = (message = '') => createLog(LumberjackLogLevel.Warning, message);
-
-const logMessage = (level: LumberjackLogEntryLevel, message = '') =>
-  resolveDependency(LumberjackService).log({
-    context: 'Test',
-    createdAt: resolveDependency(LumberjackTimeService).getUnixEpochTicks(),
-    level,
-    message,
-  });
-const logDebugMessage = (message = '') => logMessage(LumberjackLogLevel.Debug, message);
-const logErrorMessage = (message = '') => logMessage(LumberjackLogLevel.Error, message);
-const logInfoMessage = (message = '') => logMessage(LumberjackLogLevel.Info, message);
-const logWarningMessage = (message = '') => logMessage(LumberjackLogLevel.Warning, message);
+const logDebugMessage = () => resolveDependency(LumberjackService).log(createDebugLog(''));
 
 describe(LumberjackService.name, () => {
   describe('Log drivers', () => {

--- a/libs/ngworker/lumberjack/src/lib/time/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/time/index.ts
@@ -1,0 +1,1 @@
+export * from './lumberjack-time.service';

--- a/libs/ngworker/lumberjack/src/lib/time/lumberjack-time.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/time/lumberjack-time.service.spec.ts
@@ -1,0 +1,34 @@
+import { resolveDependency } from '@internal/test-util';
+
+import { LumberjackTimeService } from './lumberjack-time.service';
+
+describe(LumberjackTimeService.name, () => {
+  beforeEach(() => {
+    service = resolveDependency(LumberjackTimeService);
+  });
+
+  let service: LumberjackTimeService;
+
+  describe('getUnixEpocTicks', () => {
+    it('returns the current number of milliseconds since the Unix epoch', () => {
+      const fakeDate = new Date('2020-10-10T20:20:20Z');
+      const expectedTicks = fakeDate.valueOf();
+      spyOn(Date, 'now').and.returnValue(expectedTicks);
+
+      const actualTicks = service.getUnixEpochTicks();
+
+      expect(actualTicks).toBe(expectedTicks);
+    });
+  });
+
+  describe('utcTimeStampFor', () => {
+    it('formats an ISO-8601 date-time string with 0 hours UTC offset and milliseconds resolution', () => {
+      const expectedText = '2020-07-01T00:00:00.000Z';
+      const ticks = new Date(expectedText).valueOf();
+
+      const actualText = service.utcTimestampFor(ticks);
+
+      expect(actualText).toBe(expectedText);
+    });
+  });
+});

--- a/libs/ngworker/lumberjack/src/lib/time/lumberjack-time.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/time/lumberjack-time.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LumberjackTimeService {
+  getUnixEpochTicks(): number {
+    return Date.now();
+  }
+
+  utcTimestampFor(unixEpochTicks: number) {
+    return new Date(unixEpochTicks).toISOString();
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

1. Timestamps are created at the time of writing the log to the drivers rather than when the log entry was created.
1. No timestamp property on `LumberjackLog`.
1. Timestamp is created non-deterministically.
1. Log factory functions are exposed.

Issue Number: N/A

## What is the new behavior?

1. - [x] A timestamp property on the log entry represents when it was created
1. - [x] A `createdAt: number` property is added to `LumberjackLog`.
1. - [x] A `LumberjackTimeService` is used to determine the timestamp and its formatter.
1. - [x] Log factory functions are removed.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

Log creators are removed, `LumberjackLog#createdAt` is added.

## Other information
