### PR TITLE
chore: use dist path in e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,6 @@ jobs:
 
       - name: Use lumberjack library builds
         run: yarn use:dist
-
       - name: Cache library build artifacts
         uses: actions/cache@v2
         id: lib-build-cache
@@ -168,5 +167,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-yarn-
       - run: yarn install
+
+      - name: Use lumberjack library builds
+        run: yarn use:dist
+      - name: Cache library build artifacts
+        uses: actions/cache@v2
+        id: lib-build-cache
+        with:
+          path: dist/ngworker/lumberjack
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-
+      - name: Build Lumberjack library
+        if: steps.lib-build-cache.outputs.cache-hit != 'true'
+        run: yarn build:lib
 
       - run: yarn e2e


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `e2e` job is not using the packed library in the `dist` folder.

Issue Number: N/A

## What is the new behavior?
The `e2e` job uses the packed library in the `dist` folder so that we are actually using the library bundle for our end-to-end tests.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
