### PR TITLE
chore: fix app CI job, add Angular 8.1 to e2e job and build only one library bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,44 @@ jobs:
 
       - run: yarn lint
 
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+        angular-version: [10.1.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Use Angular version ${{ matrix.angular-version }}
+        uses: ngworker/angular-versions-action@v2
+        with:
+          angular_version: ${{ matrix.angular-version }}
+
+      - name: Variable-Yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache Yarn cache directory
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-yarn-
+      - run: yarn install
+
+      - name: Cache library bundle
+        uses: actions/cache@v2
+        with:
+          path: dist/ngworker/lumberjack
+          key: ${{ runner.os }}-lumberjack-${{ github.sha }}
+      - run: yarn build:lib
+
   lib:
     runs-on: ubuntu-latest
 
@@ -61,11 +99,11 @@ jobs:
         with:
           angular_version: ${{ matrix.angular-version }}
 
-      - name: Get yarn cache directory path
+      - name: Variable-Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
+      - name: Cache Yarn cache directory
+        uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -73,24 +111,12 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-yarn-
       - run: yarn install
 
-      - name: Cache library build artifacts
-        uses: actions/cache@v2
-        id: lib-build-cache
-        with:
-          path: dist/ngworker/lumberjack
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-
-      - name: Build Lumberjack library
-        if: steps.lib-build-cache.outputs.cache-hit != 'true'
-        run: yarn build:lib
-
       - run: yarn test:internal:ci
       - run: yarn test:lib:ci
 
   app:
     runs-on: ubuntu-latest
-    needs: lib
+    needs: build
 
     strategy:
       matrix:
@@ -108,11 +134,11 @@ jobs:
         with:
           angular_version: ${{ matrix.angular-version }}
 
-      - name: Get yarn cache directory path
+      - name: Variable-Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
+      - name: Cache Yarn cache directory
+        uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -122,17 +148,11 @@ jobs:
 
       - name: Use lumberjack library builds
         run: yarn use:dist
-      - name: Cache library build artifacts
+      - name: Cache library bundle
         uses: actions/cache@v2
-        id: lib-build-cache
         with:
           path: dist/ngworker/lumberjack
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-
-      - name: Build Lumberjack library
-        if: steps.lib-build-cache.outputs.cache-hit != 'true'
-        run: yarn build:lib
+          key: ${{ runner.os }}-lumberjack-${{ github.sha }}
 
       - run: yarn build
       - run: yarn test:ci
@@ -157,11 +177,11 @@ jobs:
         with:
           angular_version: ${{ matrix.angular-version }}
 
-      - name: Get yarn cache directory path
+      - name: Variable-Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
+      - name: Cache Yarn cache directory
+        uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -171,16 +191,10 @@ jobs:
 
       - name: Use lumberjack library builds
         run: yarn use:dist
-      - name: Cache library build artifacts
+      - name: Cache library bundle
         uses: actions/cache@v2
-        id: lib-build-cache
         with:
           path: dist/ngworker/lumberjack
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-
-      - name: Build Lumberjack library
-        if: steps.lib-build-cache.outputs.cache-hit != 'true'
-        run: yarn build:lib
+          key: ${{ runner.os }}-lumberjack-${{ github.sha }}
 
       - run: yarn e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
 
   app:
     runs-on: ubuntu-latest
+    needs: lib
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
-        angular-version: [9.0.x, 10.0.x, 10.1.x]
+        angular-version: [8.1.x, 9.0.x, 10.0.x, 10.1.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,6 @@ jobs:
 
       - name: Use lumberjack library builds
         run: yarn use:dist
-
       - name: Cache library build artifacts
         uses: actions/cache@v2
         id: lib-build-cache
@@ -168,5 +167,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-yarn-
       - run: yarn install
+
+      - name: Use lumberjack library builds
+        run: yarn use:dist
+      - name: Cache library build artifacts
+        uses: actions/cache@v2
+        id: lib-build-cache
+        with:
+          path: dist/ngworker/lumberjack
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-lumberjack-
+      - name: Build Lumberjack library
+        if: steps.lib-build-cache.outputs.cache-hit != 'true'
+        run: yarn build:lib
 
       - run: yarn e2e

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.service.ts
@@ -21,8 +21,7 @@ export class LumberjackService {
     @Inject(LumberjackLogConfigToken) private config: LumberjackLogConfig,
     // Each driver must be provided with multi. That way we can capture every provided driver
     // and use it to log to its output.
-    // tslint:disable-next-line: no-any no-null-keyword
-    @Optional() @Inject(LogDriverToken) logDrivers: LogDriver[] = null as any
+    @Optional() @Inject(LogDriverToken) logDrivers: LogDriver[]
   ) {
     logDrivers = logDrivers || [];
     this.logDrivers = Array.isArray(logDrivers) ? logDrivers : [logDrivers];

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.service.ts
@@ -21,7 +21,8 @@ export class LumberjackService {
     @Inject(LumberjackLogConfigToken) private config: LumberjackLogConfig,
     // Each driver must be provided with multi. That way we can capture every provided driver
     // and use it to log to its output.
-    @Optional() @Inject(LogDriverToken) logDrivers?: LogDriver[]
+    // tslint:disable-next-line: no-any no-null-keyword
+    @Optional() @Inject(LogDriverToken) logDrivers: LogDriver[] = null as any
   ) {
     logDrivers = logDrivers || [];
     this.logDrivers = Array.isArray(logDrivers) ? logDrivers : [logDrivers];

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "publish": "cd dist/ngworker/lumberjack && npm publish",
     "ci": "yarn install && yarn lint && yarn build:lib && yarn test:internal:ci && yarn test:lib:ci && yarn build && yarn test:ci && yarn e2e",
     "format": "npx prettier --config prettier.config.js --write \"**/*.*\" \"!dist/**\" \"!yarn.lock\"",
-    "use:dist": "json -I -f tsconfig.json -e 'this.compilerOptions.paths = { \"@ngworker/lumberjack\": [\"dist/ngworker/lumberjack\"], \"@ngworker/lumberjack/*\": \"dist/lumberjack/*\" };'"
+    "use:dist": "npx json -I -f tsconfig.json -e 'this.compilerOptions.paths = { \"@ngworker/lumberjack\": [\"dist/ngworker/lumberjack\"], \"@ngworker/lumberjack/*\": [\"dist/lumberjack/*\"] };'"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "publish": "cd dist/ngworker/lumberjack && npm publish",
     "ci": "yarn install && yarn lint && yarn build:lib && yarn test:internal:ci && yarn test:lib:ci && yarn build && yarn test:ci && yarn e2e",
     "format": "npx prettier --config prettier.config.js --write \"**/*.*\" \"!dist/**\" \"!yarn.lock\"",
-    "use:dist": "json -I -f tsconfig.json -e 'this.compilerOptions.paths[\"@ngworker/*\"] = [\"dist/ngworker/*\"]; delete this.compilerOptions.paths[\"@ngworker/lumberjack/*-driver\"]; delete this.compilerOptions.paths[\"@ngworker/lumberjack\"]'"
+    "use:dist": "json -I -f tsconfig.json -e 'this.compilerOptions.paths = { \"@ngworker/lumberjack\": [\"dist/ngworker/lumberjack\"], \"@ngworker/lumberjack/*\": \"dist/lumberjack/*\" };'"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "publish": "cd dist/ngworker/lumberjack && npm publish",
     "ci": "yarn install && yarn lint && yarn build:lib && yarn test:internal:ci && yarn test:lib:ci && yarn build && yarn test:ci && yarn e2e",
     "format": "npx prettier --config prettier.config.js --write \"**/*.*\" \"!dist/**\" \"!yarn.lock\"",
-    "use:dist": "npx json -I -f tsconfig.json -e 'this.compilerOptions.paths = { \"@ngworker/lumberjack\": [\"dist/ngworker/lumberjack\"], \"@ngworker/lumberjack/*\": [\"dist/lumberjack/*\"] };'"
+    "use:dist": "npx json -I -f tsconfig.json -e 'this.compilerOptions.paths = { \"@ngworker/lumberjack\": [\"dist/ngworker/lumberjack\"], \"@ngworker/lumberjack/*\": [\"dist/ngworker/lumberjack/*\"] };'"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

1. The `app` job is not waiting for a new library bundle to be built.
1. Angular 8.1 is not used in the `e2e` job.
1. A library bundle per Angular version is created.

Issue Number: N/A

## What is the new behavior?

1. A `build` job is extracted which the `app` and `e2e` jobs depend on.
1. Angular 8.1 is added to the `e2e` job matrix.
1. Only one library bundle is created and passed to all run of the `app` and `e2e` jobs.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
