### PR TITLE
feat: 🎸 add prodMode option to config used for configure levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ export class ConsoleDriverModule {
   static forRoot(config: LogDriverConfig = defaultLogDriverConfig): ModuleWithProviders<ConsoleDriverRootModule> {
     return {
       ngModule: ConsoleDriverRootModule,
-      providers: [{ provide: LogDriverConfigToken, useValue: config }],
+      providers: [{ provide: logDriverConfigToken, useValue: config }],
     };
   }
 
@@ -226,13 +226,13 @@ export class ConsoleDriverModule {
 
 In this implementation the `ConsoleDriverModule` is protected from being used directly. Instead we should use the `forRoot()` method.
 
-The `forRoot()` method provides the `LogDriverConfigToken` and returns the `ConsoleDriverRootModule` which holds the rest of the driver setup.
+The `forRoot()` method provides the `logDriverConfigToken` and returns the `ConsoleDriverRootModule` which holds the rest of the driver setup.
 
 ```typescript
 @NgModule({
   providers: [
     {
-      provide: LogDriverToken,
+      provide: logDriverToken,
       useClass: ConsoleDriver,
       multi: true,
     },
@@ -249,7 +249,7 @@ export class ConsoleDriverRootModule {
 }
 ```
 
-The most important thing about the `ConsoleDriverRootModule` is that it provides the `ConsoleDriver` using the `LogDriverToken` using the `multi` flag on.
+The most important thing about the `ConsoleDriverRootModule` is that it provides the `ConsoleDriver` using the `logDriverToken` using the `multi` flag on.
 
 This allows us to provide multiple `log-drivers` at the same time and is the feature enabling the extensibility of the `lumberjack` library.
 

--- a/libs/internal/console-driver/test-util/src/lib/noop-console/noop-console.module.ts
+++ b/libs/internal/console-driver/test-util/src/lib/noop-console/noop-console.module.ts
@@ -1,6 +1,6 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
 
-import { LumberjackConsoleToken } from '@ngworker/lumberjack/console-driver';
+import { lumberjackConsoleToken } from '@ngworker/lumberjack/console-driver';
 
 import { NoopConsole } from './noop-console.service';
 
@@ -8,7 +8,7 @@ import { NoopConsole } from './noop-console.service';
   providers: [
     {
       deps: [[new Optional(), new SkipSelf(), NoopConsole]],
-      provide: LumberjackConsoleToken,
+      provide: lumberjackConsoleToken,
       useFactory: (maybeExistingInstance: NoopConsole | null): NoopConsole =>
         maybeExistingInstance || new NoopConsole(),
     },

--- a/libs/internal/console-driver/test-util/src/lib/spy-console/spy-console.module.ts
+++ b/libs/internal/console-driver/test-util/src/lib/spy-console/spy-console.module.ts
@@ -1,6 +1,6 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
 
-import { LumberjackConsoleToken } from '@ngworker/lumberjack/console-driver';
+import { lumberjackConsoleToken } from '@ngworker/lumberjack/console-driver';
 
 import { SpyConsole } from './spy-console.service';
 
@@ -8,7 +8,7 @@ import { SpyConsole } from './spy-console.service';
   providers: [
     {
       deps: [[new Optional(), new SkipSelf(), SpyConsole]],
-      provide: LumberjackConsoleToken,
+      provide: lumberjackConsoleToken,
       useFactory: (maybeExistingInstance: SpyConsole | null): SpyConsole => maybeExistingInstance || new SpyConsole(),
     },
   ],

--- a/libs/internal/test-util/src/lib/noop-driver/noop-driver-config.token.ts
+++ b/libs/internal/test-util/src/lib/noop-driver/noop-driver-config.token.ts
@@ -1,7 +1,6 @@
 import { inject, InjectionToken } from '@angular/core';
 
-import { LogDriverConfig, LogDriverConfigToken } from '@ngworker/lumberjack';
-
-export const NoopDriverConfigToken = new InjectionToken<LogDriverConfig>('No-op driver config', {
-  factory: () => inject(LogDriverConfigToken),
+import { LogDriverConfig, logDriverConfigToken } from '@ngworker/lumberjack';
+export const noopDriverConfigToken = new InjectionToken<LogDriverConfig>('__NO-OP_DRIVER_CONFIG__', {
+  factory: () => inject(logDriverConfigToken),
 });

--- a/libs/internal/test-util/src/lib/noop-driver/noop-driver-root.module.ts
+++ b/libs/internal/test-util/src/lib/noop-driver/noop-driver-root.module.ts
@@ -1,13 +1,13 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
 
-import { LogDriverToken } from '@ngworker/lumberjack';
+import { logDriverToken } from '@ngworker/lumberjack';
 
 import { NoopDriver } from './noop.driver';
 
 @NgModule({
   providers: [
     {
-      provide: LogDriverToken,
+      provide: logDriverToken,
       useClass: NoopDriver,
       multi: true,
     },

--- a/libs/internal/test-util/src/lib/noop-driver/noop-driver.module.ts
+++ b/libs/internal/test-util/src/lib/noop-driver/noop-driver.module.ts
@@ -2,7 +2,7 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { LogDriverConfig } from '@ngworker/lumberjack';
 
-import { NoopDriverConfigToken } from './noop-driver-config.token';
+import { noopDriverConfigToken } from './noop-driver-config.token';
 import { NoopDriverRootModule } from './noop-driver-root.module';
 
 /**
@@ -15,7 +15,7 @@ export class NoopDriverModule {
   static forRoot(config?: LogDriverConfig): ModuleWithProviders<NoopDriverRootModule> {
     return {
       ngModule: NoopDriverRootModule,
-      providers: (config && [{ provide: NoopDriverConfigToken, useValue: config }]) || [],
+      providers: (config && [{ provide: noopDriverConfigToken, useValue: config }]) || [],
     };
   }
 

--- a/libs/internal/test-util/src/lib/noop-driver/noop.driver.ts
+++ b/libs/internal/test-util/src/lib/noop-driver/noop.driver.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 
 import { LogDriver, LogDriverConfig } from '@ngworker/lumberjack';
 
-import { NoopDriverConfigToken } from './noop-driver-config.token';
+import { noopDriverConfigToken } from './noop-driver-config.token';
 
 /**
  * No-op log driver.
@@ -11,7 +11,7 @@ import { NoopDriverConfigToken } from './noop-driver-config.token';
  */
 @Injectable()
 export class NoopDriver implements LogDriver {
-  constructor(@Inject(NoopDriverConfigToken) public config: LogDriverConfig) {}
+  constructor(@Inject(noopDriverConfigToken) public config: LogDriverConfig) {}
 
   logCritical(logEntry: string): void {}
 

--- a/libs/internal/test-util/src/lib/spy-driver/spy-driver-config.token.ts
+++ b/libs/internal/test-util/src/lib/spy-driver/spy-driver-config.token.ts
@@ -1,7 +1,7 @@
 import { inject, InjectionToken } from '@angular/core';
 
-import { LogDriverConfig, LogDriverConfigToken } from '@ngworker/lumberjack';
+import { LogDriverConfig, logDriverConfigToken } from '@ngworker/lumberjack';
 
-export const SpyDriverConfigToken = new InjectionToken<LogDriverConfig>('Spy driver config', {
-  factory: () => inject(LogDriverConfigToken),
+export const spyDriverConfigToken = new InjectionToken<LogDriverConfig>('__SPY_DRIVER_CONFIG__', {
+  factory: () => inject(logDriverConfigToken),
 });

--- a/libs/internal/test-util/src/lib/spy-driver/spy-driver-root.module.ts
+++ b/libs/internal/test-util/src/lib/spy-driver/spy-driver-root.module.ts
@@ -1,13 +1,13 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
 
-import { LogDriverToken } from '@ngworker/lumberjack';
+import { logDriverToken } from '@ngworker/lumberjack';
 
 import { SpyDriver } from './spy.driver';
 
 @NgModule({
   providers: [
     {
-      provide: LogDriverToken,
+      provide: logDriverToken,
       useClass: SpyDriver,
       multi: true,
     },

--- a/libs/internal/test-util/src/lib/spy-driver/spy-driver.module.ts
+++ b/libs/internal/test-util/src/lib/spy-driver/spy-driver.module.ts
@@ -2,7 +2,7 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { LogDriverConfig } from '@ngworker/lumberjack';
 
-import { SpyDriverConfigToken } from './spy-driver-config.token';
+import { spyDriverConfigToken } from './spy-driver-config.token';
 import { SpyDriverRootModule } from './spy-driver-root.module';
 
 /**
@@ -15,7 +15,7 @@ export class SpyDriverModule {
   static forRoot(config?: LogDriverConfig): ModuleWithProviders<SpyDriverRootModule> {
     return {
       ngModule: SpyDriverRootModule,
-      providers: (config && [{ provide: SpyDriverConfigToken, useValue: config }]) || [],
+      providers: (config && [{ provide: spyDriverConfigToken, useValue: config }]) || [],
     };
   }
 

--- a/libs/internal/test-util/src/lib/spy-driver/spy.driver.ts
+++ b/libs/internal/test-util/src/lib/spy-driver/spy.driver.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 
 import { LogDriver, LogDriverConfig } from '@ngworker/lumberjack';
 
-import { SpyDriverConfigToken } from './spy-driver-config.token';
+import { spyDriverConfigToken } from './spy-driver-config.token';
 
 /**
  * Spy log driver.
@@ -11,7 +11,7 @@ import { SpyDriverConfigToken } from './spy-driver-config.token';
  */
 @Injectable()
 export class SpyDriver implements LogDriver, jasmine.SpyObj<LogDriver> {
-  constructor(@Inject(SpyDriverConfigToken) public config: LogDriverConfig) {}
+  constructor(@Inject(spyDriverConfigToken) public config: LogDriverConfig) {}
 
   logCritical = jasmine.createSpy('logCritical');
 

--- a/libs/ngworker/lumberjack/console-driver/src/lib/console-driver-config.token.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/console-driver-config.token.spec.ts
@@ -1,9 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 
 import { resolveDependency } from '@internal/test-util';
-import { LogDriverConfig, LogDriverConfigToken, LumberjackLogLevel } from '@ngworker/lumberjack';
+import { LogDriverConfig, logDriverConfigToken, LumberjackLogLevel } from '@ngworker/lumberjack';
 
-import { ConsoleDriverConfigToken } from './console-driver-config.token';
+import { consoleDriverConfigToken } from './console-driver-config.token';
 
 const debugDriverConfig: LogDriverConfig = {
   levels: [LumberjackLogLevel.Debug],
@@ -12,19 +12,19 @@ const verboseDriverConfig: LogDriverConfig = {
   levels: [LumberjackLogLevel.Verbose],
 };
 
-describe('ConsoleDriverConfigToken', () => {
+describe('consoleDriverConfigToken', () => {
   describe('given a provided console log driver config', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         providers: [
-          { provide: LogDriverConfigToken, useValue: verboseDriverConfig },
-          { provide: ConsoleDriverConfigToken, useValue: debugDriverConfig },
+          { provide: logDriverConfigToken, useValue: verboseDriverConfig },
+          { provide: consoleDriverConfigToken, useValue: debugDriverConfig },
         ],
       });
     });
 
     it('then that config is resolved', () => {
-      const actualDriverConfig = resolveDependency(ConsoleDriverConfigToken);
+      const actualDriverConfig = resolveDependency(consoleDriverConfigToken);
 
       expect(actualDriverConfig).toBe(debugDriverConfig);
     });
@@ -33,12 +33,12 @@ describe('ConsoleDriverConfigToken', () => {
   describe('given no provided console log driver config', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [{ provide: LogDriverConfigToken, useValue: verboseDriverConfig }],
+        providers: [{ provide: logDriverConfigToken, useValue: verboseDriverConfig }],
       });
     });
 
     it('then the value of the log driver config is resolved', () => {
-      const actualDriverConfig = resolveDependency(ConsoleDriverConfigToken);
+      const actualDriverConfig = resolveDependency(consoleDriverConfigToken);
 
       expect(actualDriverConfig).toBe(verboseDriverConfig);
     });

--- a/libs/ngworker/lumberjack/console-driver/src/lib/console-driver-config.token.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/console-driver-config.token.ts
@@ -1,7 +1,7 @@
 import { inject, InjectionToken } from '@angular/core';
 
-import { LogDriverConfig, LogDriverConfigToken } from '@ngworker/lumberjack';
+import { LogDriverConfig, logDriverConfigToken } from '@ngworker/lumberjack';
 
-export const ConsoleDriverConfigToken = new InjectionToken<LogDriverConfig>('Console driver config', {
-  factory: () => inject(LogDriverConfigToken),
+export const consoleDriverConfigToken = new InjectionToken<LogDriverConfig>('__CONSOLE_DRIVER_CONFIG__', {
+  factory: () => inject(logDriverConfigToken),
 });

--- a/libs/ngworker/lumberjack/console-driver/src/lib/console-driver-root.module.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/console-driver-root.module.ts
@@ -1,13 +1,13 @@
 import { Inject, NgModule, Optional, SkipSelf } from '@angular/core';
 
-import { LogDriverToken } from '@ngworker/lumberjack';
+import { logDriverToken } from '@ngworker/lumberjack';
 
 import { ConsoleDriver } from './console.driver';
 
 @NgModule({
   providers: [
     {
-      provide: LogDriverToken,
+      provide: logDriverToken,
       useClass: ConsoleDriver,
       multi: true,
     },

--- a/libs/ngworker/lumberjack/console-driver/src/lib/console-driver.module.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/console-driver.module.spec.ts
@@ -4,8 +4,8 @@ import { expectNgModuleToBeGuarded, resolveDependency } from '@internal/test-uti
 import {
   LogDriver,
   LogDriverConfig,
-  LogDriverToken,
-  LumberjackLogConfigToken,
+  logDriverToken,
+  lumberjackLogConfigToken,
   LumberjackLogLevel,
   LumberjackModule,
 } from '@ngworker/lumberjack';
@@ -28,7 +28,7 @@ const createConsoleDriver = ({
     ],
   });
 
-  const [consoleDriver] = (resolveDependency(LogDriverToken) as unknown) as LogDriver[];
+  const [consoleDriver] = (resolveDependency(logDriverToken) as unknown) as LogDriver[];
 
   return consoleDriver;
 };
@@ -60,7 +60,7 @@ describe(ConsoleDriverModule.name, () => {
       const consoleDriver = createConsoleDriver();
 
       const actualConfig = consoleDriver.config;
-      const logConfig = resolveDependency(LumberjackLogConfigToken);
+      const logConfig = resolveDependency(lumberjackLogConfigToken);
       const defaultLogDriverConfig: LogDriverConfig = {
         levels: logConfig.levels,
       };

--- a/libs/ngworker/lumberjack/console-driver/src/lib/console-driver.module.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/console-driver.module.spec.ts
@@ -2,10 +2,10 @@ import { TestBed } from '@angular/core/testing';
 
 import { expectNgModuleToBeGuarded, resolveDependency } from '@internal/test-util';
 import {
-  defaultLogDriverConfig,
   LogDriver,
   LogDriverConfig,
   LogDriverToken,
+  LumberjackLogConfigToken,
   LumberjackLogLevel,
   LumberjackModule,
 } from '@ngworker/lumberjack';
@@ -57,12 +57,14 @@ describe(ConsoleDriverModule.name, () => {
     });
 
     it('registers a default configuration if none is specified', () => {
-      const expectedConfig = defaultLogDriverConfig;
-
       const consoleDriver = createConsoleDriver();
 
       const actualConfig = consoleDriver.config;
-      expect(actualConfig).toEqual(expectedConfig);
+      const logConfig = resolveDependency(LumberjackLogConfigToken);
+      const defaultLogDriverConfig: LogDriverConfig = {
+        levels: logConfig.levels,
+      };
+      expect(actualConfig).toEqual(defaultLogDriverConfig);
     });
 
     it('does register the specified log driver configuration when the lumberjack module is imported after the console driver module', () => {

--- a/libs/ngworker/lumberjack/console-driver/src/lib/console-driver.module.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/console-driver.module.ts
@@ -2,7 +2,7 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { LogDriverConfig } from '@ngworker/lumberjack';
 
-import { ConsoleDriverConfigToken } from './console-driver-config.token';
+import { consoleDriverConfigToken } from './console-driver-config.token';
 import { ConsoleDriverRootModule } from './console-driver-root.module';
 
 @NgModule()
@@ -10,7 +10,7 @@ export class ConsoleDriverModule {
   static forRoot(config?: LogDriverConfig): ModuleWithProviders<ConsoleDriverRootModule> {
     return {
       ngModule: ConsoleDriverRootModule,
-      providers: (config && [{ provide: ConsoleDriverConfigToken, useValue: config }]) || [],
+      providers: (config && [{ provide: consoleDriverConfigToken, useValue: config }]) || [],
     };
   }
 

--- a/libs/ngworker/lumberjack/console-driver/src/lib/console.driver.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/console.driver.spec.ts
@@ -2,11 +2,11 @@ import { TestBed } from '@angular/core/testing';
 
 import { SpyConsole, SpyConsoleModule } from '@internal/console-driver/test-util';
 import { resolveDependency } from '@internal/test-util';
-import { LogDriver, LogDriverToken, LumberjackLogLevel } from '@ngworker/lumberjack';
+import { LogDriver, logDriverToken, LumberjackLogLevel } from '@ngworker/lumberjack';
 
 import { ConsoleDriverModule } from './console-driver.module';
 import { ConsoleDriver } from './console.driver';
-import { LumberjackConsoleToken } from './lumberjack-console.token';
+import { lumberjackConsoleToken } from './lumberjack-console.token';
 
 describe(ConsoleDriver.name, () => {
   beforeEach(() => {
@@ -14,9 +14,9 @@ describe(ConsoleDriver.name, () => {
       imports: [ConsoleDriverModule.forRoot({ levels: [LumberjackLogLevel.Verbose] }), SpyConsoleModule],
     });
 
-    const [_driver] = (resolveDependency(LogDriverToken) as unknown) as LogDriver[];
+    const [_driver] = (resolveDependency(logDriverToken) as unknown) as LogDriver[];
     driver = _driver as ConsoleDriver;
-    spyLogger = resolveDependency(LumberjackConsoleToken) as SpyConsole;
+    spyLogger = resolveDependency(lumberjackConsoleToken) as SpyConsole;
   });
 
   let driver: ConsoleDriver;

--- a/libs/ngworker/lumberjack/console-driver/src/lib/console.driver.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/console.driver.ts
@@ -2,15 +2,15 @@ import { Inject, Injectable } from '@angular/core';
 
 import { LogDriver, LogDriverConfig } from '@ngworker/lumberjack';
 
-import { ConsoleDriverConfigToken } from './console-driver-config.token';
+import { consoleDriverConfigToken } from './console-driver-config.token';
 import { LumberjackConsole } from './lumberjack-console';
-import { LumberjackConsoleToken } from './lumberjack-console.token';
+import { lumberjackConsoleToken } from './lumberjack-console.token';
 
 @Injectable()
 export class ConsoleDriver implements LogDriver {
   constructor(
-    @Inject(ConsoleDriverConfigToken) public config: LogDriverConfig,
-    @Inject(LumberjackConsoleToken) private console: LumberjackConsole
+    @Inject(consoleDriverConfigToken) public config: LogDriverConfig,
+    @Inject(lumberjackConsoleToken) private console: LumberjackConsole
   ) {}
 
   logCritical(logEntry: string): void {

--- a/libs/ngworker/lumberjack/console-driver/src/lib/lumberjack-console.token.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/lumberjack-console.token.spec.ts
@@ -1,10 +1,10 @@
 import { resolveDependency } from '@internal/test-util';
 
-import { LumberjackConsoleToken } from './lumberjack-console.token';
+import { lumberjackConsoleToken } from './lumberjack-console.token';
 
-describe('LumberjackConsoleToken', () => {
+describe('lumberjackConsoleToken', () => {
   it('resolves to the console by default', () => {
-    const actualConsoleLogger = resolveDependency(LumberjackConsoleToken);
+    const actualConsoleLogger = resolveDependency(lumberjackConsoleToken);
 
     expect(actualConsoleLogger).toBe(console);
   });

--- a/libs/ngworker/lumberjack/console-driver/src/lib/lumberjack-console.token.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/lumberjack-console.token.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 import { LumberjackConsole } from './lumberjack-console';
 
-export const LumberjackConsoleToken = new InjectionToken<LumberjackConsole>('Lumberjack Console', {
+export const lumberjackConsoleToken = new InjectionToken<LumberjackConsole>('__LUMBERJACK_CONSOLE__', {
   factory: (): LumberjackConsole => console,
   providedIn: 'root',
 });

--- a/libs/ngworker/lumberjack/http-driver/README.md
+++ b/libs/ngworker/lumberjack/http-driver/README.md
@@ -33,7 +33,7 @@ export class HttpDriver implements LogDriver {
 
   constructor(
     private http: HttpClient,
-    @Inject(HttpDriverConfigToken) public config: HttpDriverConfig,
+    @Inject(httpDriverConfigToken) public config: HttpDriverConfig,
     private ngZone: NgZone
   ) {}
 
@@ -151,7 +151,7 @@ export class HttpDriverModule {
       ngModule: HttpDriverRootModule,
       providers: [
         {
-          provide: HttpDriverConfigToken,
+          provide: httpDriverConfigToken,
           useValue: config,
         },
       ],
@@ -185,9 +185,9 @@ export function httpDriverFactory(
   imports: [HttpClientModule],
   providers: [
     {
-      deps: [HttpClient, LogDriverConfigToken, HttpDriverConfigToken, NgZone],
+      deps: [HttpClient, logDriverConfigToken, httpDriverConfigToken, NgZone],
       multi: true,
-      provide: LogDriverToken,
+      provide: logDriverToken,
       useFactory: httpDriverFactory,
     },
   ],
@@ -203,7 +203,7 @@ export class HttpDriverRootModule {
 }
 ```
 
-We now have the `deps` property, needed to inject the dependencies. In this case the `HttpClient`, the `ngZone`, the `LogDriverConfigToken` and the `HttpDriverConfigToken`.
+We now have the `deps` property, needed to inject the dependencies. In this case the `HttpClient`, the `ngZone`, the `logDriverConfigToken` and the `httpDriverConfigToken`.
 
 This dependencies are used in the `httpDriverFactory` function.
 There, we merge the `logDriverConfig` and `httpDriverConfig` to ensure we have the default configurations, in they are not override, and we return a new instance of the `HttpDriver`.

--- a/libs/ngworker/lumberjack/http-driver/src/lib/http-driver-config.token.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/lib/http-driver-config.token.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 import { LogDriverConfig } from '@ngworker/lumberjack';
 
-export const HttpDriverConfigToken: InjectionToken<HttpDriverConfig> = new InjectionToken('__HTTP_DRIVER_CONFIG__');
+export const httpDriverConfigToken: InjectionToken<HttpDriverConfig> = new InjectionToken('__HTTP_DRIVER_CONFIG__');
 
 export interface HttpDriverConfig extends LogDriverConfig {
   /**

--- a/libs/ngworker/lumberjack/http-driver/src/lib/http-driver-root.module.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/lib/http-driver-root.module.ts
@@ -1,9 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, NgModule, NgZone, Optional, SkipSelf } from '@angular/core';
 
-import { LogDriverConfig, LogDriverConfigToken, LogDriverToken } from '@ngworker/lumberjack';
+import { LogDriverConfig, logDriverConfigToken, logDriverToken } from '@ngworker/lumberjack';
 
-import { HttpDriverConfig, HttpDriverConfigToken } from './http-driver-config.token';
+import { HttpDriverConfig, httpDriverConfigToken } from './http-driver-config.token';
 import { HttpDriver } from './http.driver';
 
 export function httpDriverFactory(
@@ -23,9 +23,9 @@ export function httpDriverFactory(
 @NgModule({
   providers: [
     {
-      deps: [HttpClient, LogDriverConfigToken, HttpDriverConfigToken, NgZone],
+      deps: [HttpClient, logDriverConfigToken, httpDriverConfigToken, NgZone],
       multi: true,
-      provide: LogDriverToken,
+      provide: logDriverToken,
       useFactory: httpDriverFactory,
     },
   ],

--- a/libs/ngworker/lumberjack/http-driver/src/lib/http-driver.module.spec.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/lib/http-driver.module.spec.ts
@@ -5,8 +5,8 @@ import { expectNgModuleToBeGuarded, resolveDependency } from '@internal/test-uti
 import {
   LogDriver,
   LogDriverConfig,
-  LogDriverToken,
-  LumberjackLogConfigToken,
+  logDriverToken,
+  lumberjackLogConfigToken,
   LumberjackLogLevel,
   LumberjackModule,
 } from '@ngworker/lumberjack';
@@ -34,7 +34,7 @@ const createHttpDriver = (
     ],
   });
 
-  const [httpDriver] = (resolveDependency(LogDriverToken) as unknown) as LogDriver[];
+  const [httpDriver] = (resolveDependency(logDriverToken) as unknown) as LogDriver[];
 
   return httpDriver;
 };
@@ -56,7 +56,7 @@ const createHttpDriverWithOptions = (
     ],
   });
 
-  const [httpDriver] = (resolveDependency(LogDriverToken) as unknown) as LogDriver[];
+  const [httpDriver] = (resolveDependency(logDriverToken) as unknown) as LogDriver[];
 
   return httpDriver;
 };
@@ -98,7 +98,7 @@ describe(HttpDriverModule.name, () => {
       const httpDriver = createHttpDriver({ config: customHttpConfig });
 
       const actualConfig = httpDriver.config;
-      const logConfig = resolveDependency(LumberjackLogConfigToken);
+      const logConfig = resolveDependency(lumberjackLogConfigToken);
       const defaultLogDriverConfig: LogDriverConfig = {
         levels: logConfig.levels,
       };

--- a/libs/ngworker/lumberjack/http-driver/src/lib/http-driver.module.spec.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/lib/http-driver.module.spec.ts
@@ -3,9 +3,10 @@ import { TestBed } from '@angular/core/testing';
 
 import { expectNgModuleToBeGuarded, resolveDependency } from '@internal/test-util';
 import {
-  defaultLogDriverConfig,
   LogDriver,
+  LogDriverConfig,
   LogDriverToken,
+  LumberjackLogConfigToken,
   LumberjackLogLevel,
   LumberjackModule,
 } from '@ngworker/lumberjack';
@@ -93,11 +94,15 @@ describe(HttpDriverModule.name, () => {
         origin: 'TEST_MODULE',
         logWagonSize: 5,
       };
-      const expectedConfig: HttpDriverConfig = { ...defaultLogDriverConfig, ...customHttpConfig };
 
       const httpDriver = createHttpDriver({ config: customHttpConfig });
 
       const actualConfig = httpDriver.config;
+      const logConfig = resolveDependency(LumberjackLogConfigToken);
+      const defaultLogDriverConfig: LogDriverConfig = {
+        levels: logConfig.levels,
+      };
+      const expectedConfig: HttpDriverConfig = { ...defaultLogDriverConfig, ...customHttpConfig };
       expect(actualConfig).toEqual(expectedConfig);
     });
 

--- a/libs/ngworker/lumberjack/http-driver/src/lib/http-driver.module.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/lib/http-driver.module.ts
@@ -1,6 +1,6 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
-import { HttpDriverConfig, HttpDriverConfigToken } from './http-driver-config.token';
+import { HttpDriverConfig, httpDriverConfigToken } from './http-driver-config.token';
 import { HttpDriverOptions } from './http-driver-options';
 import { HttpDriverRootModule } from './http-driver-root.module';
 
@@ -14,7 +14,7 @@ export class HttpDriverModule {
       ngModule: HttpDriverRootModule,
       providers: [
         {
-          provide: HttpDriverConfigToken,
+          provide: httpDriverConfigToken,
           useValue: config,
         },
       ],
@@ -30,7 +30,7 @@ export class HttpDriverModule {
       ngModule: HttpDriverRootModule,
       providers: [
         {
-          provide: HttpDriverConfigToken,
+          provide: httpDriverConfigToken,
           useValue: options,
         },
       ],

--- a/libs/ngworker/lumberjack/http-driver/src/lib/http.driver.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/lib/http.driver.ts
@@ -5,7 +5,7 @@ import { tap } from 'rxjs/operators';
 
 import { LogDriver, LumberjackLogLevel } from '@ngworker/lumberjack';
 
-import { HttpDriverConfig, HttpDriverConfigToken } from './http-driver-config.token';
+import { HttpDriverConfig, httpDriverConfigToken } from './http-driver-config.token';
 
 interface HttpLogEntry {
   logEntry: string;
@@ -23,7 +23,7 @@ export class HttpDriver implements LogDriver {
 
   constructor(
     private http: HttpClient,
-    @Inject(HttpDriverConfigToken) public config: HttpDriverConfig,
+    @Inject(httpDriverConfigToken) public config: HttpDriverConfig,
     private ngZone: NgZone
   ) {}
 

--- a/libs/ngworker/lumberjack/src/lib/configs/default-development-levels.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/default-development-levels.ts
@@ -1,0 +1,3 @@
+import { LumberjackLogConfigLevel, LumberjackLogLevel } from '../lumberjack-log-levels';
+
+export const defaultDevelopmentLevels: LumberjackLogConfigLevel = [LumberjackLogLevel.Verbose];

--- a/libs/ngworker/lumberjack/src/lib/configs/default-production-levels.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/default-production-levels.ts
@@ -1,0 +1,8 @@
+import { LumberjackLogConfigLevel, LumberjackLogLevel } from '../lumberjack-log-levels';
+
+export const defaultProductionLevels: LumberjackLogConfigLevel = [
+  LumberjackLogLevel.Critical,
+  LumberjackLogLevel.Error,
+  LumberjackLogLevel.Info,
+  LumberjackLogLevel.Warning,
+];

--- a/libs/ngworker/lumberjack/src/lib/configs/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/index.ts
@@ -1,4 +1,5 @@
 export * from './log-driver.config';
 
 export * from './lumberjack-log.config';
+export * from './lumberjack-log.options';
 export * from './lumberjack-log-config.token';

--- a/libs/ngworker/lumberjack/src/lib/configs/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/index.ts
@@ -1,2 +1,4 @@
 export * from './log-driver.config';
-export { LumberjackLogConfigToken, LumberjackLogConfig, LumberjackLogOptions } from './lumberjack-log.config';
+
+export * from './lumberjack-log.config';
+export * from './lumberjack-log-config.token';

--- a/libs/ngworker/lumberjack/src/lib/configs/index.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/index.ts
@@ -1,2 +1,2 @@
 export * from './log-driver.config';
-export * from './lumberjack-log.config';
+export { LumberjackLogConfigToken, LumberjackLogConfig, LumberjackLogOptions } from './lumberjack-log.config';

--- a/libs/ngworker/lumberjack/src/lib/configs/log-driver.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/log-driver.config.ts
@@ -13,7 +13,3 @@ export interface LogDriverConfig {
    */
   readonly levels: ReadonlyArray<LumberjackLogEntryLevel> | [LumberjackLogLevel.Verbose];
 }
-
-export const defaultLogDriverConfig: LogDriverConfig = {
-  levels: [LumberjackLogLevel.Verbose],
-};

--- a/libs/ngworker/lumberjack/src/lib/configs/log-driver.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/log-driver.config.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 import { LumberjackLogEntryLevel, LumberjackLogLevel } from '../lumberjack-log-levels';
 
-export const LogDriverConfigToken: InjectionToken<LogDriverConfig> = new InjectionToken('__LOG_DRIVER_CONFIG__');
+export const logDriverConfigToken: InjectionToken<LogDriverConfig> = new InjectionToken('__LOG_DRIVER_CONFIG__');
 
 export interface LogDriverConfig {
   /**

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log-config.token.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log-config.token.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+import { LumberjackLogConfig } from './lumberjack-log.config';
+
+export const lumberjackLogConfigToken: InjectionToken<LumberjackLogConfig> = new InjectionToken(
+  '__LUMBERJACK_LOG_CONFIG__'
+);

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log-options.token.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log-options.token.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+import { LumberjackLogOptions } from './lumberjack-log.options';
+
+export const lumberjackLogOptionsToken: InjectionToken<LumberjackLogOptions> = new InjectionToken(
+  '__TEMP_LUMBERJACK_LOG_OPTIONS__'
+);

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
@@ -1,22 +1,15 @@
-import { inject, InjectionToken } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 
 import { LumberjackLog } from '../lumberjack-log';
-import { LumberjackTimeService } from '../time/lumberjack-time.service';
+import { LumberjackLogConfigLevel } from '../lumberjack-log-levels';
 
 export const LumberjackLogConfigToken: InjectionToken<LumberjackLogConfig> = new InjectionToken(
-  '__LUMBERJACK_LOG_CONFIG__',
-  {
-    factory: (): LumberjackLogConfig => {
-      const time = inject(LumberjackTimeService);
-
-      return {
-        format: ({ context, createdAt: timestamp, level, message }) =>
-          `${level}  ${time.utcTimestampFor(timestamp)} ${context ? `[${context}]` : ''} ${message}`,
-      };
-    },
-  }
+  '__LUMBERJACK_LOG_CONFIG__'
 );
 
 export interface LumberjackLogConfig {
-  format(logEntry: LumberjackLog): string;
+  format: (logEntry: LumberjackLog) => string;
+  levels: LumberjackLogConfigLevel;
 }
+
+export type LumberjackLogOptions = Partial<LumberjackLogConfig>;

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
@@ -1,28 +1,7 @@
-import { InjectionToken } from '@angular/core';
-
 import { LumberjackLog } from '../lumberjack-log';
-import { LumberjackLogConfigLevel, LumberjackLogLevel } from '../lumberjack-log-levels';
-
-export const LumberjackLogConfigToken: InjectionToken<LumberjackLogConfig> = new InjectionToken(
-  '__LUMBERJACK_LOG_CONFIG__'
-);
-
-export const LumberjackLogOptionsToken: InjectionToken<LumberjackLogOptions> = new InjectionToken(
-  '__TEMP_LUMBERJACK_LOG_OPTIONS__'
-);
+import { LumberjackLogConfigLevel } from '../lumberjack-log-levels';
 
 export interface LumberjackLogConfig {
   format: (logEntry: LumberjackLog) => string;
   levels: LumberjackLogConfigLevel;
 }
-
-export type LumberjackLogOptions = Partial<LumberjackLogConfig>;
-
-export const defaultProductionLevels: LumberjackLogConfigLevel = [
-  LumberjackLogLevel.Critical,
-  LumberjackLogLevel.Error,
-  LumberjackLogLevel.Info,
-  LumberjackLogLevel.Warning,
-];
-
-export const defaultDevelopmentLevels: LumberjackLogConfigLevel = [LumberjackLogLevel.Verbose];

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.config.ts
@@ -1,10 +1,14 @@
 import { InjectionToken } from '@angular/core';
 
 import { LumberjackLog } from '../lumberjack-log';
-import { LumberjackLogConfigLevel } from '../lumberjack-log-levels';
+import { LumberjackLogConfigLevel, LumberjackLogLevel } from '../lumberjack-log-levels';
 
 export const LumberjackLogConfigToken: InjectionToken<LumberjackLogConfig> = new InjectionToken(
   '__LUMBERJACK_LOG_CONFIG__'
+);
+
+export const LumberjackLogOptionsToken: InjectionToken<LumberjackLogOptions> = new InjectionToken(
+  '__TEMP_LUMBERJACK_LOG_OPTIONS__'
 );
 
 export interface LumberjackLogConfig {
@@ -13,3 +17,12 @@ export interface LumberjackLogConfig {
 }
 
 export type LumberjackLogOptions = Partial<LumberjackLogConfig>;
+
+export const defaultProductionLevels: LumberjackLogConfigLevel = [
+  LumberjackLogLevel.Critical,
+  LumberjackLogLevel.Error,
+  LumberjackLogLevel.Info,
+  LumberjackLogLevel.Warning,
+];
+
+export const defaultDevelopmentLevels: LumberjackLogConfigLevel = [LumberjackLogLevel.Verbose];

--- a/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.options.ts
+++ b/libs/ngworker/lumberjack/src/lib/configs/lumberjack-log.options.ts
@@ -1,0 +1,3 @@
+import { LumberjackLogConfig } from './lumberjack-log.config';
+
+export type LumberjackLogOptions = Partial<LumberjackLogConfig>;

--- a/libs/ngworker/lumberjack/src/lib/environment/is-production-environment.token.ts
+++ b/libs/ngworker/lumberjack/src/lib/environment/is-production-environment.token.ts
@@ -1,0 +1,6 @@
+import { InjectionToken, isDevMode } from '@angular/core';
+
+export const isProductionEnvironmentToken = new InjectionToken<boolean>('Production mode detection', {
+  factory: () => !isDevMode(),
+  providedIn: 'root',
+});

--- a/libs/ngworker/lumberjack/src/lib/environment/is-production-environment.token.ts
+++ b/libs/ngworker/lumberjack/src/lib/environment/is-production-environment.token.ts
@@ -1,6 +1,6 @@
 import { InjectionToken, isDevMode } from '@angular/core';
 
-export const isProductionEnvironmentToken = new InjectionToken<boolean>('Production mode detection', {
+export const isProductionEnvironmentToken = new InjectionToken<boolean>('__PRODUCTION_MODE_DETECTION__', {
   factory: () => !isDevMode(),
   providedIn: 'root',
 });

--- a/libs/ngworker/lumberjack/src/lib/log-drivers/log-driver.ts
+++ b/libs/ngworker/lumberjack/src/lib/log-drivers/log-driver.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 import { LogDriverConfig } from '../configs/log-driver.config';
 
-export const LogDriverToken: InjectionToken<LogDriver> = new InjectionToken('__LUMBERJACK_LOG_DRIVER_TOKEN__');
+export const logDriverToken: InjectionToken<LogDriver> = new InjectionToken('__LUMBERJACK_LOG_DRIVER_TOKEN__');
 
 export interface LogDriver {
   config: LogDriverConfig;

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-log-levels.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-log-levels.ts
@@ -12,4 +12,6 @@ export enum LumberjackLogLevel {
   Warning = 'warn',
 }
 
+export type LumberjackLogConfigLevel = ReadonlyArray<LumberjackLogEntryLevel> | [LumberjackLogLevel.Verbose];
+
 export type LumberjackLogEntryLevel = Exclude<LumberjackLogLevel, LumberjackLogLevel.Verbose>;

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.ts
@@ -1,12 +1,12 @@
 import { Inject, NgModule, Optional, SkipSelf } from '@angular/core';
 
-import { LogDriverConfig, LogDriverConfigToken, LumberjackLogConfig, LumberjackLogConfigToken } from './configs';
-import {
-  defaultDevelopmentLevels,
-  defaultProductionLevels,
-  LumberjackLogOptions,
-  LumberjackLogOptionsToken,
-} from './configs/lumberjack-log.config';
+import { defaultDevelopmentLevels } from './configs/default-development-levels';
+import { defaultProductionLevels } from './configs/default-production-levels';
+import { LogDriverConfig, logDriverConfigToken } from './configs/log-driver.config';
+import { lumberjackLogConfigToken } from './configs/lumberjack-log-config.token';
+import { lumberjackLogOptionsToken } from './configs/lumberjack-log-options.token';
+import { LumberjackLogConfig } from './configs/lumberjack-log.config';
+import { LumberjackLogOptions } from './configs/lumberjack-log.options';
 import { isProductionEnvironmentToken } from './environment/is-production-environment.token';
 import { LumberjackTimeService } from './time/lumberjack-time.service';
 
@@ -33,13 +33,13 @@ export function logDriverConfigFactory({ levels }: LumberjackLogConfig): LogDriv
 @NgModule({
   providers: [
     {
-      deps: [LumberjackLogOptionsToken, isProductionEnvironmentToken, LumberjackTimeService],
-      provide: LumberjackLogConfigToken,
+      deps: [lumberjackLogOptionsToken, isProductionEnvironmentToken, LumberjackTimeService],
+      provide: lumberjackLogConfigToken,
       useFactory: logConfigFactory,
     },
     {
-      deps: [LumberjackLogConfigToken],
-      provide: LogDriverConfigToken,
+      deps: [lumberjackLogConfigToken],
+      provide: logDriverConfigToken,
       useFactory: logDriverConfigFactory,
     },
   ],

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.ts
@@ -17,7 +17,7 @@ export function logConfigFactory(
 ): LumberjackLogConfig {
   return {
     format({ context, createdAt: timestamp, level, message }) {
-      return `${level}  ${time.utcTimestampFor(timestamp)} ${context ? `[${context}]` : ''} ${message}`;
+      return `${level} ${time.utcTimestampFor(timestamp)}${context ? ` [${context}]` : ''} ${message}`;
     },
     levels: isProductionEnvironment ? defaultProductionLevels : defaultDevelopmentLevels,
     ...options,

--- a/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack-root.module.ts
@@ -1,12 +1,17 @@
 import { Inject, NgModule, Optional, SkipSelf } from '@angular/core';
 
 import { LogDriverConfig, LogDriverConfigToken, LumberjackLogConfig, LumberjackLogConfigToken } from './configs';
+import {
+  defaultDevelopmentLevels,
+  defaultProductionLevels,
+  LumberjackLogOptions,
+  LumberjackLogOptionsToken,
+} from './configs/lumberjack-log.config';
 import { isProductionEnvironmentToken } from './environment/is-production-environment.token';
-import { LumberjackLogLevel } from './lumberjack-log-levels';
 import { LumberjackTimeService } from './time/lumberjack-time.service';
 
 export function logConfigFactory(
-  options: Partial<LumberjackLogConfig> = {},
+  options: LumberjackLogOptions = {},
   isProductionEnvironment: boolean,
   time: LumberjackTimeService
 ): LumberjackLogConfig {
@@ -14,9 +19,7 @@ export function logConfigFactory(
     format({ context, createdAt: timestamp, level, message }) {
       return `${level}  ${time.utcTimestampFor(timestamp)} ${context ? `[${context}]` : ''} ${message}`;
     },
-    levels: isProductionEnvironment
-      ? [LumberjackLogLevel.Critical, LumberjackLogLevel.Error, LumberjackLogLevel.Info, LumberjackLogLevel.Warning]
-      : [LumberjackLogLevel.Verbose],
+    levels: isProductionEnvironment ? defaultProductionLevels : defaultDevelopmentLevels,
     ...options,
   };
 }
@@ -30,11 +33,7 @@ export function logDriverConfigFactory({ levels }: LumberjackLogConfig): LogDriv
 @NgModule({
   providers: [
     {
-      deps: [
-        [new Optional(), new SkipSelf(), LumberjackLogConfigToken],
-        isProductionEnvironmentToken,
-        LumberjackTimeService,
-      ],
+      deps: [LumberjackLogOptionsToken, isProductionEnvironmentToken, LumberjackTimeService],
       provide: LumberjackLogConfigToken,
       useFactory: logConfigFactory,
     },

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
@@ -2,7 +2,8 @@ import { TestBed } from '@angular/core/testing';
 
 import { expectNgModuleToBeGuarded, resolveDependency } from '@internal/test-util';
 
-import { defaultLogDriverConfig, LogDriverConfigToken, LumberjackLogConfig, LumberjackLogConfigToken } from './configs';
+import { LogDriverConfig, LogDriverConfigToken, LumberjackLogConfig, LumberjackLogConfigToken } from './configs';
+import { LumberjackLogLevel } from './lumberjack-log-levels';
 import { LumberjackModule } from './lumberjack.module';
 
 describe(LumberjackModule.name, () => {
@@ -14,6 +15,7 @@ describe(LumberjackModule.name, () => {
     it('accepts a log configuration', () => {
       const expectedConfig: LumberjackLogConfig = {
         format: ({ message }) => message,
+        levels: [LumberjackLogLevel.Debug],
       };
 
       TestBed.configureTestingModule({
@@ -32,6 +34,7 @@ describe(LumberjackModule.name, () => {
       const actualConfig = resolveDependency(LumberjackLogConfigToken);
       expect(actualConfig).toEqual({
         format: jasmine.any(Function),
+        levels: jasmine.any(Array),
       });
     });
 
@@ -39,6 +42,10 @@ describe(LumberjackModule.name, () => {
       TestBed.configureTestingModule({
         imports: [LumberjackModule.forRoot()],
       });
+      const logConfig = resolveDependency(LumberjackLogConfigToken);
+      const defaultLogDriverConfig: LogDriverConfig = {
+        levels: logConfig.levels,
+      };
 
       const actualConfig = resolveDependency(LogDriverConfigToken);
       expect(actualConfig).toEqual(defaultLogDriverConfig);

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
@@ -118,7 +118,7 @@ describe(LumberjackModule.name, () => {
         fakeTimestamp = time.utcTimestampFor(fakeTicks);
       });
 
-      it('format correctly when having a context', () => {
+      it('formats a log entry with a context', () => {
         const entryLogWithContext: LumberjackLog = {
           context: 'TestSuite',
           createdAt: fakeTicks,
@@ -135,7 +135,7 @@ describe(LumberjackModule.name, () => {
         expect(format(entryLogWithContext)).toEqual(expectedMessageWithContext);
       });
 
-      it('format correctly when having a context', () => {
+      it('formats a log entry with no context', () => {
         const entryLogWithOutContext: LumberjackLog = {
           createdAt: fakeTicks,
           level: LumberjackLogLevel.Critical,

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
@@ -128,7 +128,7 @@ describe(LumberjackModule.name, () => {
 
         const { context, level, message } = entryLogWithContext;
 
-        const expectedMessageWithContext = `${level}  ${fakeTimestamp} [${context}] ${message}`;
+        const expectedMessageWithContext = `${level} ${fakeTimestamp} [${context}] ${message}`;
 
         const { format } = resolveDependency(lumberjackLogConfigToken);
 
@@ -144,7 +144,7 @@ describe(LumberjackModule.name, () => {
 
         const { level, message } = entryLogWithOutContext;
 
-        const expectedMessageWithContext = `${level}  ${fakeTimestamp}  ${message}`;
+        const expectedMessageWithContext = `${level} ${fakeTimestamp} ${message}`;
 
         const { format } = resolveDependency(lumberjackLogConfigToken);
 

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.module.spec.ts
@@ -3,6 +3,12 @@ import { TestBed } from '@angular/core/testing';
 import { expectNgModuleToBeGuarded, resolveDependency } from '@internal/test-util';
 
 import { LogDriverConfig, LogDriverConfigToken, LumberjackLogConfig, LumberjackLogConfigToken } from './configs';
+import {
+  defaultDevelopmentLevels,
+  defaultProductionLevels,
+  LumberjackLogOptions,
+} from './configs/lumberjack-log.config';
+import { isProductionEnvironmentToken } from './environment/is-production-environment.token';
 import { LumberjackLogLevel } from './lumberjack-log-levels';
 import { LumberjackModule } from './lumberjack.module';
 
@@ -26,15 +32,65 @@ describe(LumberjackModule.name, () => {
       expect(actualConfig).toEqual(expectedConfig);
     });
 
-    it('provides a default log configuration', () => {
+    it('accepts a partial log configuration in development mode', () => {
+      const config: LumberjackLogOptions = {
+        format: ({ message }) => message,
+      };
+      const expectedConfig: LumberjackLogOptions = {
+        ...config,
+        levels: defaultDevelopmentLevels,
+      };
+
+      TestBed.configureTestingModule({
+        imports: [LumberjackModule.forRoot(config)],
+        providers: [{ provide: isProductionEnvironmentToken, useValue: false }],
+      });
+
+      const actualConfig = resolveDependency(LumberjackLogConfigToken);
+      expect(actualConfig).toEqual(expectedConfig as LumberjackLogConfig);
+    });
+
+    it('accepts a partial log configuration in production mode', () => {
+      const config: LumberjackLogOptions = {
+        format: ({ message }) => message,
+      };
+      const expectedConfig: LumberjackLogOptions = {
+        ...config,
+        levels: defaultProductionLevels,
+      };
+
+      TestBed.configureTestingModule({
+        imports: [LumberjackModule.forRoot(config)],
+        providers: [{ provide: isProductionEnvironmentToken, useValue: true }],
+      });
+
+      const actualConfig = resolveDependency(LumberjackLogConfigToken);
+      expect(actualConfig).toEqual(expectedConfig as LumberjackLogConfig);
+    });
+
+    it('provides a default log configuration in development mode', () => {
       TestBed.configureTestingModule({
         imports: [LumberjackModule.forRoot()],
+        providers: [{ provide: isProductionEnvironmentToken, useValue: false }],
       });
 
       const actualConfig = resolveDependency(LumberjackLogConfigToken);
       expect(actualConfig).toEqual({
         format: jasmine.any(Function),
-        levels: jasmine.any(Array),
+        levels: defaultDevelopmentLevels,
+      });
+    });
+
+    it('provides a default log configuration in production mode', () => {
+      TestBed.configureTestingModule({
+        imports: [LumberjackModule.forRoot()],
+        providers: [{ provide: isProductionEnvironmentToken, useValue: true }],
+      });
+
+      const actualConfig = resolveDependency(LumberjackLogConfigToken);
+      expect(actualConfig).toEqual({
+        format: jasmine.any(Function),
+        levels: defaultProductionLevels,
       });
     });
 

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.module.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.module.ts
@@ -1,6 +1,6 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
-import { LumberjackLogConfigToken, LumberjackLogOptions } from './configs/lumberjack-log.config';
+import { LumberjackLogOptions, LumberjackLogOptionsToken } from './configs/lumberjack-log.config';
 import { LumberjackRootModule } from './lumberjack-root.module';
 
 @NgModule()
@@ -8,7 +8,7 @@ export class LumberjackModule {
   static forRoot(options?: LumberjackLogOptions): ModuleWithProviders<LumberjackRootModule> {
     return {
       ngModule: LumberjackRootModule,
-      providers: (options && [{ provide: LumberjackLogConfigToken, useValue: options }]) || [],
+      providers: [{ provide: LumberjackLogOptionsToken, useValue: options }],
     };
   }
 

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.module.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.module.ts
@@ -1,14 +1,14 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
-import { LumberjackLogConfig, LumberjackLogConfigToken } from './configs/lumberjack-log.config';
+import { LumberjackLogConfigToken, LumberjackLogOptions } from './configs/lumberjack-log.config';
 import { LumberjackRootModule } from './lumberjack-root.module';
 
 @NgModule()
 export class LumberjackModule {
-  static forRoot(config?: LumberjackLogConfig): ModuleWithProviders<LumberjackRootModule> {
+  static forRoot(options?: LumberjackLogOptions): ModuleWithProviders<LumberjackRootModule> {
     return {
       ngModule: LumberjackRootModule,
-      providers: (config && [{ provide: LumberjackLogConfigToken, useValue: config }]) || [],
+      providers: (options && [{ provide: LumberjackLogConfigToken, useValue: options }]) || [],
     };
   }
 

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.module.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.module.ts
@@ -1,6 +1,7 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
-import { LumberjackLogOptions, LumberjackLogOptionsToken } from './configs/lumberjack-log.config';
+import { lumberjackLogOptionsToken } from './configs/lumberjack-log-options.token';
+import { LumberjackLogOptions } from './configs/lumberjack-log.options';
 import { LumberjackRootModule } from './lumberjack-root.module';
 
 @NgModule()
@@ -8,7 +9,7 @@ export class LumberjackModule {
   static forRoot(options?: LumberjackLogOptions): ModuleWithProviders<LumberjackRootModule> {
     return {
       ngModule: LumberjackRootModule,
-      providers: [{ provide: LumberjackLogOptionsToken, useValue: options }],
+      providers: [{ provide: lumberjackLogOptionsToken, useValue: options }],
     };
   }
 

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.service.spec.ts
@@ -17,8 +17,8 @@ import {
 } from '@internal/test-util';
 import { ConsoleDriverModule } from '@ngworker/lumberjack/console-driver';
 
-import { LogDriverConfig, LogDriverConfigToken } from './configs';
-import { LogDriver, LogDriverToken } from './log-drivers';
+import { LogDriverConfig, logDriverConfigToken } from './configs';
+import { LogDriver, logDriverToken } from './log-drivers';
 import { LumberjackLogLevel } from './lumberjack-log-levels';
 import { LumberjackModule } from './lumberjack.module';
 import { LumberjackService } from './lumberjack.service';
@@ -27,7 +27,7 @@ const noLogsConfig: LogDriverConfig = {
   levels: [],
 };
 const noLogsProvider: StaticProvider = {
-  provide: LogDriverConfigToken,
+  provide: logDriverConfigToken,
   useValue: noLogsConfig,
 };
 const allLogsConfig: LogDriverConfig = {
@@ -41,14 +41,14 @@ const allLogsConfig: LogDriverConfig = {
   ],
 };
 const allLogsProvider: StaticProvider = {
-  provide: LogDriverConfigToken,
+  provide: logDriverConfigToken,
   useValue: allLogsConfig,
 };
 const verboseLoggingConfig: LogDriverConfig = {
   levels: [LumberjackLogLevel.Verbose],
 };
 const verboseLoggingProvider: StaticProvider = {
-  provide: LogDriverConfigToken,
+  provide: logDriverConfigToken,
   useValue: verboseLoggingConfig,
 };
 
@@ -99,7 +99,7 @@ describe(LumberjackService.name, () => {
 
       lumberjack = resolveDependency(LumberjackService);
 
-      const [logDriver] = (resolveDependency(LogDriverToken) as unknown) as LogDriver[];
+      const [logDriver] = (resolveDependency(logDriverToken) as unknown) as LogDriver[];
       spyDriver = logDriver as SpyDriver;
     });
 
@@ -192,7 +192,7 @@ describe(LumberjackService.name, () => {
 
       lumberjack = resolveDependency(LumberjackService);
 
-      const [logDriver] = (resolveDependency(LogDriverToken) as unknown) as LogDriver[];
+      const [logDriver] = (resolveDependency(logDriverToken) as unknown) as LogDriver[];
       spyDriver = logDriver as SpyDriver;
     });
 
@@ -250,7 +250,7 @@ describe(LumberjackService.name, () => {
 
         lumberjack = resolveDependency(LumberjackService);
 
-        const [_spyDriver, _noopDriver] = (resolveDependency(LogDriverToken) as unknown) as LogDriver[];
+        const [_spyDriver, _noopDriver] = (resolveDependency(logDriverToken) as unknown) as LogDriver[];
         spyDriver = _spyDriver as SpyDriver;
         noopDriver = _noopDriver as jasmine.SpyObj<NoopDriver>;
         spyOn(noopDriver, 'logCritical');

--- a/libs/ngworker/lumberjack/src/lib/lumberjack.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/lumberjack.service.ts
@@ -1,7 +1,8 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 
-import { LumberjackLogConfig, LumberjackLogConfigToken } from './configs/lumberjack-log.config';
-import { LogDriver, LogDriverToken } from './log-drivers';
+import { lumberjackLogConfigToken } from './configs/lumberjack-log-config.token';
+import { LumberjackLogConfig } from './configs/lumberjack-log.config';
+import { LogDriver, logDriverToken } from './log-drivers';
 import { LumberjackLog } from './lumberjack-log';
 import { LumberjackLogEntryLevel, LumberjackLogLevel } from './lumberjack-log-levels';
 import { LumberjackRootModule } from './lumberjack-root.module';
@@ -19,10 +20,10 @@ export class LumberjackService {
   private logDrivers: LogDriver[];
 
   constructor(
-    @Inject(LumberjackLogConfigToken) private config: LumberjackLogConfig,
+    @Inject(lumberjackLogConfigToken) private config: LumberjackLogConfig,
     // Each driver must be provided with multi. That way we can capture every provided driver
     // and use it to log to its output.
-    @Optional() @Inject(LogDriverToken) logDrivers: LogDriver[]
+    @Optional() @Inject(logDriverToken) logDrivers: LogDriver[]
   ) {
     logDrivers = logDrivers || [];
     this.logDrivers = Array.isArray(logDrivers) ? logDrivers : [logDrivers];
@@ -76,10 +77,6 @@ export class LumberjackService {
         break;
       case LumberjackLogLevel.Trace:
         driver.logTrace(logText);
-
-        break;
-      default:
-        driver.logInfo(logText);
 
         break;
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Lumberjack uses undefined as the default value for levels (log everything) at the `LogDriverConfig`

Issue Number: N/A

## What is the new behavior?

Lumberjack config adds a `prodMode` property to `LumberjackLogConfig` that uses as default value Angular `!isDevMode()`

When `prodMode` is on Lumberjack uses Error and Critical as default levels for `LogDriverConfig`. Otherwise, it uses the `Verbose` level as a default.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
