### PR TITLE
feat: 🎸 rename LumberjackLog property context to scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ export class MyComponent implements OnInit {
     this.lumberjack.log({
       level: LumberjackLogLevel.Info,
       message: 'Hello, World!',
-      context: 'MyComponent',
+      scope: 'MyComponent',
       createdAt: Date.now(),
     });
   }
@@ -154,8 +154,8 @@ Lumberjack replaces omitted options with defaults.
 When the `format` option is not configured, Lumberjack will use the following default formatter.
 
 ```ts
-function lumberjackFormatLog({ context, createdAt: timestamp, level, message }: LumberjackLog) {
-  return `${level} ${utcTimestampFor(timestamp)}${context ? ` [${context}]` : ''} ${message}`;
+function lumberjackFormatLog({ scope, createdAt: timestamp, level, message }: LumberjackLog) {
+  return `${level} ${utcTimestampFor(timestamp)}${scope ? ` [${scope}]` : ''} ${message}`;
 }
 ```
 
@@ -337,7 +337,7 @@ For a more advanced log driver implementation, see [LumberjackHttpDriver](https:
 
 ## Best practices
 
-Every log can be represented as a combination of its level, creation time, message, and context. Using inline logs with the `LumberjackService` can cause structure duplication and/or de-standardization.
+Every log can be represented as a combination of its level, creation time, message, and scope. Using inline logs with the `LumberjackService` can cause structure duplication and/or de-standardization.
 
 The following practices are recommended to mitigate these problems.
 
@@ -355,16 +355,16 @@ import { LumberjackService, LumberjackTimeService } from '@ngworker/lumberjack';
 export abstract class LumberjackLogger {
   constructor(lumberjack: LumberjackService, time: LumberjackTimeService) {}
 
-  protected createCriticalLogger(message: string, context?: string): () => void {}
-  protected createDebugLogger(message: string, context?: string): () => void {}
-  protected createErrorLogger(message: string, context?: string): () => void {}
-  protected createInfoLogger(message: string, context?: string): () => void {}
-  protected createTraceLogger(message: string, context?: string): () => void {}
-  protected createWarningLogger(message: string, context?: string): () => void {}
+  protected createCriticalLogger(message: string, scope?: string): () => void {}
+  protected createDebugLogger(message: string, scope?: string): () => void {}
+  protected createErrorLogger(message: string, scope?: string): () => void {}
+  protected createInfoLogger(message: string, scope?: string): () => void {}
+  protected createTraceLogger(message: string, scope?: string): () => void {}
+  protected createWarningLogger(message: string, scope?: string): () => void {}
 }
 ```
 
-By extending `LumberjackLogger`, we only have to be worry about the message and context of our pre-defined logs.
+By extending `LumberjackLogger`, we only have to be worry about the message and scope of our pre-defined logs.
 
 All logger factory methods are protected as it is recommended to create a custom logger per _context_ rather than using logger factories directly in a consumer.
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ export abstract class LumberjackLogger {
 
 By extending `LumberjackLogger`, we only have to be worry about the message and scope of our pre-defined logs.
 
-All logger factory methods are protected as it is recommended to create a custom logger per _context_ rather than using logger factories directly in a consumer.
+All logger factory methods are protected as it is recommended to create a custom logger per _scope_ rather than using logger factories directly in a consumer.
 
 As an example, let's create a custom logger for our example application.
 
@@ -378,11 +378,11 @@ import { LumberjackLogger } from '@ngworker/lumberjack';
   providedIn: 'root',
 })
 export class AppLogger extends LumberjackLogger {
-  public static logContext = 'Forest App';
+  public static logScope = 'Forest App';
 
-  forestOnFire = this.createCriticalLogger('The forest is on fire!', AppLogger.logContext);
+  forestOnFire = this.createCriticalLogger('The forest is on fire!', AppLogger.logScope);
 
-  helloForest = this.createInfoLogger('Hello, forest!', AppLogger.logContext);
+  helloForest = this.createInfoLogger('Hello, forest!', AppLogger.logScope);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -378,11 +378,11 @@ import { LumberjackLogger } from '@ngworker/lumberjack';
   providedIn: 'root',
 })
 export class AppLogger extends LumberjackLogger {
-  public static logScope = 'Forest App';
+  public static scope = 'Forest App';
 
-  forestOnFire = this.createCriticalLogger('The forest is on fire!', AppLogger.logScope);
+  forestOnFire = this.createCriticalLogger('The forest is on fire!', AppLogger.scope);
 
-  helloForest = this.createInfoLogger('Hello, forest!', AppLogger.logScope);
+  helloForest = this.createInfoLogger('Hello, forest!', AppLogger.scope);
 }
 ```
 

--- a/apps/lumberjack-app/src/app/app-logger.service.ts
+++ b/apps/lumberjack-app/src/app/app-logger.service.ts
@@ -6,13 +6,13 @@ import { LumberjackLogger, LumberjackService, LumberjackTimeService } from '@ngw
   providedIn: 'root',
 })
 export class AppLogger extends LumberjackLogger {
-  public static logScope = 'Forest App';
+  public static scope = 'Forest App';
 
   constructor(lumberjack: LumberjackService, time: LumberjackTimeService) {
     super(lumberjack, time);
   }
 
-  forestOnFire = this.createCriticalLogger('The forest is on fire', AppLogger.logScope);
+  forestOnFire = this.createCriticalLogger('The forest is on fire', AppLogger.scope);
 
-  helloForest = this.createInfoLogger('HelloForest', AppLogger.logScope);
+  helloForest = this.createInfoLogger('HelloForest', AppLogger.scope);
 }

--- a/apps/lumberjack-app/src/app/app-logger.service.ts
+++ b/apps/lumberjack-app/src/app/app-logger.service.ts
@@ -6,13 +6,13 @@ import { LumberjackLogger, LumberjackService, LumberjackTimeService } from '@ngw
   providedIn: 'root',
 })
 export class AppLogger extends LumberjackLogger {
-  public static logContext = 'Forest App';
+  public static logScope = 'Forest App';
 
   constructor(lumberjack: LumberjackService, time: LumberjackTimeService) {
     super(lumberjack, time);
   }
 
-  forestOnFire = this.createCriticalLogger('The forest is on fire', AppLogger.logContext);
+  forestOnFire = this.createCriticalLogger('The forest is on fire', AppLogger.logScope);
 
-  helloForest = this.createInfoLogger('HelloForest', AppLogger.logContext);
+  helloForest = this.createInfoLogger('HelloForest', AppLogger.logScope);
 }

--- a/libs/internal/test-util/src/lib/logs/log-creators.ts
+++ b/libs/internal/test-util/src/lib/logs/log-creators.ts
@@ -2,20 +2,17 @@ import { LumberjackLevel, LumberjackLogLevel, LumberjackTimeService } from '@ngw
 
 import { resolveDependency } from '../angular/resolve-dependency';
 
-const createLog = (level: LumberjackLogLevel, message = '', context = 'Test') => ({
-  context,
+const createLog = (level: LumberjackLogLevel, message = '', scope = 'Test') => ({
+  scope,
   createdAt: resolveDependency(LumberjackTimeService).getUnixEpochTicks(),
   level,
   message,
 });
-export const createCriticalLog = (message?: string, context?: string) =>
-  createLog(LumberjackLevel.Critical, message, context);
-export const createDebugLog = (message?: string, context?: string) =>
-  createLog(LumberjackLevel.Debug, message, context);
-export const createErrorLog = (message?: string, context?: string) =>
-  createLog(LumberjackLevel.Error, message, context);
-export const createInfoLog = (message?: string, context?: string) => createLog(LumberjackLevel.Info, message, context);
-export const createTraceLog = (message?: string, context?: string) =>
-  createLog(LumberjackLevel.Trace, message, context);
-export const createWarningLog = (message?: string, context?: string) =>
-  createLog(LumberjackLevel.Warning, message, context);
+export const createCriticalLog = (message?: string, scope?: string) =>
+  createLog(LumberjackLevel.Critical, message, scope);
+export const createDebugLog = (message?: string, scope?: string) => createLog(LumberjackLevel.Debug, message, scope);
+export const createErrorLog = (message?: string, scope?: string) => createLog(LumberjackLevel.Error, message, scope);
+export const createInfoLog = (message?: string, scope?: string) => createLog(LumberjackLevel.Info, message, scope);
+export const createTraceLog = (message?: string, scope?: string) => createLog(LumberjackLevel.Trace, message, scope);
+export const createWarningLog = (message?: string, scope?: string) =>
+  createLog(LumberjackLevel.Warning, message, scope);

--- a/libs/ngworker/lumberjack/src/lib/configuration/lumberjack.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/configuration/lumberjack.module.spec.ts
@@ -123,36 +123,36 @@ describe(LumberjackModule.name, () => {
       });
 
       it('formats a log with a scope', () => {
-        const logWithContext: LumberjackLog = {
+        const logWithScope: LumberjackLog = {
           scope: 'TestSuite',
           createdAt: fakeTicks,
           level: LumberjackLevel.Critical,
           message: 'Test Message',
         };
 
-        const { scope, level, message } = logWithContext;
+        const { scope, level, message } = logWithScope;
 
         const expectedFormattedLog = `${level} ${fakeTimestamp} [${scope}] ${message}`;
 
         const { format } = resolveDependency(lumberjackConfigToken);
 
-        expect(format(logWithContext)).toBe(expectedFormattedLog);
+        expect(format(logWithScope)).toBe(expectedFormattedLog);
       });
 
       it('formats a log with no scope', () => {
-        const logWithoutContext: LumberjackLog = {
+        const logWithoutScope: LumberjackLog = {
           createdAt: fakeTicks,
           level: LumberjackLevel.Critical,
           message: 'Test Message',
         };
 
-        const { level, message } = logWithoutContext;
+        const { level, message } = logWithoutScope;
 
         const expectedFormattedLog = `${level} ${fakeTimestamp} ${message}`;
 
         const { format } = resolveDependency(lumberjackConfigToken);
 
-        expect(format(logWithoutContext)).toEqual(expectedFormattedLog);
+        expect(format(logWithoutScope)).toEqual(expectedFormattedLog);
       });
     });
   });

--- a/libs/ngworker/lumberjack/src/lib/configuration/lumberjack.module.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/configuration/lumberjack.module.spec.ts
@@ -122,24 +122,24 @@ describe(LumberjackModule.name, () => {
         fakeTimestamp = utcTimestampFor(fakeTicks);
       });
 
-      it('formats a log with a context', () => {
+      it('formats a log with a scope', () => {
         const logWithContext: LumberjackLog = {
-          context: 'TestSuite',
+          scope: 'TestSuite',
           createdAt: fakeTicks,
           level: LumberjackLevel.Critical,
           message: 'Test Message',
         };
 
-        const { context, level, message } = logWithContext;
+        const { scope, level, message } = logWithContext;
 
-        const expectedFormattedLog = `${level} ${fakeTimestamp} [${context}] ${message}`;
+        const expectedFormattedLog = `${level} ${fakeTimestamp} [${scope}] ${message}`;
 
         const { format } = resolveDependency(lumberjackConfigToken);
 
         expect(format(logWithContext)).toBe(expectedFormattedLog);
       });
 
-      it('formats a log with no context', () => {
+      it('formats a log with no scope', () => {
         const logWithoutContext: LumberjackLog = {
           createdAt: fakeTicks,
           level: LumberjackLevel.Critical,

--- a/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.spec.ts
@@ -8,15 +8,15 @@ import { lumberjackFormatLog } from './lumberjack-format-log';
 
 function parseFormattedLog(formattedLog: string) {
   const formattedLogPattern = /^([a-z]+) ([0-9\.:\-TZ]+) (\[(.+)\] )?(.*)$/;
-  const [_, level, timestamp, taggedContextWithEndingSpace = '', scope = '', message] =
+  const [_, level, timestamp, taggedScopeWithEndingSpace = '', scope = '', message] =
     formattedLogPattern.exec(formattedLog) || [];
-  const taggedContext = taggedContextWithEndingSpace ? taggedContextWithEndingSpace.slice(0, -1) : '';
+  const taggedScope = taggedScopeWithEndingSpace ? taggedScopeWithEndingSpace.slice(0, -1) : '';
 
   return {
     scope,
     level,
     message,
-    taggedContext,
+    taggedScope,
     timestamp,
   };
 }
@@ -74,17 +74,17 @@ describe(lumberjackFormatLog.name, () => {
   });
 
   describe('Scope', () => {
-    const scopes = ['Test scope', 'TestContext', 'test.scope'];
+    const scopes = ['Test scope', 'TestScope', 'test.scope'];
 
-    scopes.forEach((expectedContext) => {
+    scopes.forEach((expectedScope) => {
       it('tags the specified scope', () => {
-        const log = createDebugLog(undefined, expectedContext);
+        const log = createDebugLog(undefined, expectedScope);
 
         const formattedLog = lumberjackFormatLog(log);
 
-        const { scope: actualContext, taggedContext } = parseFormattedLog(formattedLog);
-        expect(actualContext).toBe(expectedContext);
-        expect(taggedContext).toBe(`[${expectedContext}]`);
+        const { scope: actualScope, taggedScope } = parseFormattedLog(formattedLog);
+        expect(actualScope).toBe(expectedScope);
+        expect(taggedScope).toBe(`[${expectedScope}]`);
       });
     });
 
@@ -93,9 +93,9 @@ describe(lumberjackFormatLog.name, () => {
 
       const formattedLog = lumberjackFormatLog(log);
 
-      const { scope: actualContext, taggedContext } = parseFormattedLog(formattedLog);
-      expect(actualContext).toBe('');
-      expect(taggedContext).toBe('');
+      const { scope: actualScope, taggedScope } = parseFormattedLog(formattedLog);
+      expect(actualScope).toBe('');
+      expect(taggedScope).toBe('');
     });
   });
 

--- a/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.spec.ts
@@ -8,12 +8,12 @@ import { lumberjackFormatLog } from './lumberjack-format-log';
 
 function parseFormattedLog(formattedLog: string) {
   const formattedLogPattern = /^([a-z]+) ([0-9\.:\-TZ]+) (\[(.+)\] )?(.*)$/;
-  const [_, level, timestamp, taggedContextWithEndingSpace = '', context = '', message] =
+  const [_, level, timestamp, taggedContextWithEndingSpace = '', scope = '', message] =
     formattedLogPattern.exec(formattedLog) || [];
   const taggedContext = taggedContextWithEndingSpace ? taggedContextWithEndingSpace.slice(0, -1) : '';
 
   return {
-    context,
+    scope,
     level,
     message,
     taggedContext,
@@ -38,7 +38,7 @@ describe(lumberjackFormatLog.name, () => {
           createdAt: new Date().valueOf(),
           level: expectedLevel,
           message: 'Test message',
-          context: 'Test context',
+          scope: 'Test scope',
         };
 
         const formattedLog = lumberjackFormatLog(log);
@@ -62,7 +62,7 @@ describe(lumberjackFormatLog.name, () => {
           createdAt: unixEpochTicks,
           level: LumberjackLevel.Debug,
           message: 'Test message',
-          context: 'Test context',
+          scope: 'Test scope',
         };
 
         const formattedLog = lumberjackFormatLog(log);
@@ -73,27 +73,27 @@ describe(lumberjackFormatLog.name, () => {
     });
   });
 
-  describe('Context', () => {
-    const contexts = ['Test context', 'TestContext', 'test.context'];
+  describe('Scope', () => {
+    const scopes = ['Test scope', 'TestContext', 'test.scope'];
 
-    contexts.forEach((expectedContext) => {
-      it('tags the specified context', () => {
+    scopes.forEach((expectedContext) => {
+      it('tags the specified scope', () => {
         const log = createDebugLog(undefined, expectedContext);
 
         const formattedLog = lumberjackFormatLog(log);
 
-        const { context: actualContext, taggedContext } = parseFormattedLog(formattedLog);
+        const { scope: actualContext, taggedContext } = parseFormattedLog(formattedLog);
         expect(actualContext).toBe(expectedContext);
         expect(taggedContext).toBe(`[${expectedContext}]`);
       });
     });
 
-    it('does not add a tag without a context', () => {
+    it('does not add a tag without a scope', () => {
       const log = createDebugLog('Test message', '');
 
       const formattedLog = lumberjackFormatLog(log);
 
-      const { context: actualContext, taggedContext } = parseFormattedLog(formattedLog);
+      const { scope: actualContext, taggedContext } = parseFormattedLog(formattedLog);
       expect(actualContext).toBe('');
       expect(taggedContext).toBe('');
     });
@@ -103,8 +103,8 @@ describe(lumberjackFormatLog.name, () => {
     const messages = ['The forest is on fire!', 'Lumber is gold', 'Saving the Amazon Jungle'];
 
     messages.forEach((expectedMessage) => {
-      it(`places the message at the end with a context`, () => {
-        const log = createDebugLog(expectedMessage, 'Test context');
+      it(`places the message at the end with a scope`, () => {
+        const log = createDebugLog(expectedMessage, 'Test scope');
 
         const formattedLog = lumberjackFormatLog(log);
 
@@ -112,7 +112,7 @@ describe(lumberjackFormatLog.name, () => {
         expect(actualMessage).toBe(expectedMessage);
       });
 
-      it(`places the message at the end without a context`, () => {
+      it(`places the message at the end without a scope`, () => {
         const log = createDebugLog(expectedMessage, '');
 
         const formattedLog = lumberjackFormatLog(log);

--- a/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.ts
+++ b/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.ts
@@ -2,6 +2,6 @@ import { LumberjackLog } from '../logs/lumberjack.log';
 
 import { utcTimestampFor } from './utc-timestamp-for';
 
-export function lumberjackFormatLog({ context, createdAt: timestamp, level, message }: LumberjackLog) {
-  return `${level} ${utcTimestampFor(timestamp)}${context ? ` [${context}]` : ''} ${message}`;
+export function lumberjackFormatLog({ scope, createdAt: timestamp, level, message }: LumberjackLog) {
+  return `${level} ${utcTimestampFor(timestamp)}${scope ? ` [${scope}]` : ''} ${message}`;
 }

--- a/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-log-formatter.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-log-formatter.service.spec.ts
@@ -20,7 +20,7 @@ import { LumberjackLogFormatter } from './lumberjack-log-formatter.service';
 function createFormattingErrorLog(formattingErrorMessage: string, log: LumberjackLog): LumberjackLog {
   return createErrorLog(
     `Could not format message "${log.message}". Error: "${formattingErrorMessage}"`,
-    logFormattingErrorContext
+    logFormattingErrorScope
   );
 }
 
@@ -36,7 +36,7 @@ class FakeTimeService extends LumberjackTimeService {
   }
 }
 
-const logFormattingErrorContext = 'LumberjackLogFormattingError';
+const logFormattingErrorScope = 'LumberjackLogFormattingError';
 
 describe(LumberjackLogFormatter.name, () => {
   function setup(options?: LumberjackOptions) {
@@ -107,7 +107,7 @@ describe(LumberjackLogFormatter.name, () => {
       const { formattedLog: actualFormattedLog } = service.formatLog(criticalLog);
 
       expect(actualFormattedLog).toBe(
-        `${formattingErrorLog.level} ${nowTimestamp} [${logFormattingErrorContext}] ${formattingErrorLog.message}`
+        `${formattingErrorLog.level} ${nowTimestamp} [${logFormattingErrorScope}] ${formattingErrorLog.message}`
       );
     });
   });

--- a/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-log-formatter.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/formatting/lumberjack-log-formatter.service.ts
@@ -41,7 +41,7 @@ export class LumberjackLogFormatter {
     const formattingErrorMessage = (formatError as Error).message || String(formatError);
 
     return {
-      context: 'LumberjackLogFormattingError',
+      scope: 'LumberjackLogFormattingError',
       createdAt: this.time.getUnixEpochTicks(),
       level: LumberjackLevel.Error,
       message: `Could not format message "${log.message}". Error: "${formattingErrorMessage}"`,

--- a/libs/ngworker/lumberjack/src/lib/logging/lumberjack-logger.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/lumberjack-logger.service.spec.ts
@@ -20,14 +20,14 @@ import { LumberjackService } from './lumberjack.service';
   providedIn: 'root',
 })
 export class TestLogger extends LumberjackLogger {
-  static context = 'Test';
+  static scope = 'Test';
 
-  criticalLogger = this.createCriticalLogger('', TestLogger.context);
-  debugLogger = this.createDebugLogger('', TestLogger.context);
-  errorLogger = this.createErrorLogger('', TestLogger.context);
-  infoLogger = this.createInfoLogger('', TestLogger.context);
-  traceLogger = this.createTraceLogger('', TestLogger.context);
-  warningLogger = this.createWarningLogger('', TestLogger.context);
+  criticalLogger = this.createCriticalLogger('', TestLogger.scope);
+  debugLogger = this.createDebugLogger('', TestLogger.scope);
+  errorLogger = this.createErrorLogger('', TestLogger.scope);
+  infoLogger = this.createInfoLogger('', TestLogger.scope);
+  traceLogger = this.createTraceLogger('', TestLogger.scope);
+  warningLogger = this.createWarningLogger('', TestLogger.scope);
 }
 
 const fakeDate = new Date('2020-02-02T02:02:02.000Z');

--- a/libs/ngworker/lumberjack/src/lib/logging/lumberjack-logger.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/lumberjack-logger.service.ts
@@ -10,33 +10,33 @@ import { LumberjackService } from './lumberjack.service';
 export abstract class LumberjackLogger {
   constructor(private lumberjack: LumberjackService, private time: LumberjackTimeService) {}
 
-  protected createCriticalLogger(message: string, context?: string): () => void {
-    return this.createLogger(LumberjackLevel.Critical, message, context);
+  protected createCriticalLogger(message: string, scope?: string): () => void {
+    return this.createLogger(LumberjackLevel.Critical, message, scope);
   }
 
-  protected createDebugLogger(message: string, context?: string): () => void {
-    return this.createLogger(LumberjackLevel.Debug, message, context);
+  protected createDebugLogger(message: string, scope?: string): () => void {
+    return this.createLogger(LumberjackLevel.Debug, message, scope);
   }
 
-  protected createErrorLogger(message: string, context?: string): () => void {
-    return this.createLogger(LumberjackLevel.Error, message, context);
+  protected createErrorLogger(message: string, scope?: string): () => void {
+    return this.createLogger(LumberjackLevel.Error, message, scope);
   }
 
-  protected createInfoLogger(message: string, context?: string): () => void {
-    return this.createLogger(LumberjackLevel.Info, message, context);
+  protected createInfoLogger(message: string, scope?: string): () => void {
+    return this.createLogger(LumberjackLevel.Info, message, scope);
   }
 
-  protected createTraceLogger(message: string, context?: string): () => void {
-    return this.createLogger(LumberjackLevel.Trace, message, context);
+  protected createTraceLogger(message: string, scope?: string): () => void {
+    return this.createLogger(LumberjackLevel.Trace, message, scope);
   }
 
-  protected createWarningLogger(message: string, context?: string): () => void {
-    return this.createLogger(LumberjackLevel.Warning, message, context);
+  protected createWarningLogger(message: string, scope?: string): () => void {
+    return this.createLogger(LumberjackLevel.Warning, message, scope);
   }
 
-  private createLogger(level: LumberjackLogLevel, message: string, context?: string): () => void {
+  private createLogger(level: LumberjackLogLevel, message: string, scope?: string): () => void {
     return () => {
-      this.lumberjack.log({ context, createdAt: this.time.getUnixEpochTicks(), level, message });
+      this.lumberjack.log({ scope, createdAt: this.time.getUnixEpochTicks(), level, message });
     };
   }
 }

--- a/libs/ngworker/lumberjack/src/lib/logging/lumberjack.service.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/lumberjack.service.ts
@@ -48,7 +48,7 @@ export class LumberjackService {
 
   private createDriverErrorLog(driverError: LumberjackLogDriverError): LumberjackLog {
     return {
-      context: 'LumberjackLogDriverError',
+      scope: 'LumberjackLogDriverError',
       createdAt: this.time.getUnixEpochTicks(),
       level: LumberjackLevel.Error,
       message: formatLogDriverError(driverError),

--- a/libs/ngworker/lumberjack/src/lib/logs/lumberjack.log.ts
+++ b/libs/ngworker/lumberjack/src/lib/logs/lumberjack.log.ts
@@ -5,9 +5,9 @@ import { LumberjackLogLevel } from './lumberjack-log-level';
  */
 export interface LumberjackLog {
   /**
-   * Context, for example domain, application, component, or service.
+   * Scope, for example domain, application, component, or service.
    */
-  readonly context?: string;
+  readonly scope?: string;
   /**
    * Unix epoch ticks (milliseconds) timestamp when log entry was created.
    */


### PR DESCRIPTION
BREAKING CHANGE: LumberjackLog property context was renamed to scope

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`LumberjackLog` uses context to denote the origin or scope of an instance log.

Issue Number: N/A

## What is the new behavior?

`LumberjackLog` renames context property to scope.

Scope is a more suitable name for the intent of the property and now context can be used in the future for different purposes like holding correlation ids.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```
Any client application of custom driver must perform the same property rename across their source code logs.

## Other information
