### PR TITLE
test: simplify tests by using LumberjackLogFactory

### DIFF
--- a/libs/ngworker/lumberjack/console-driver/src/lib/log-drivers/lumberjack-console.driver.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/log-drivers/lumberjack-console.driver.spec.ts
@@ -4,11 +4,10 @@ import { SpyConsole, SpyConsoleModule } from '@internal/console-driver/test-util
 import { resolveDependency } from '@internal/test-util';
 import {
   LumberjackLevel,
-  LumberjackLogBuilder,
   LumberjackLogDriver,
   lumberjackLogDriverToken,
+  LumberjackLogFactory,
   LumberjackModule,
-  LumberjackTimeService,
 } from '@ngworker/lumberjack';
 
 import { LumberjackConsoleDriverModule } from '../configuration/lumberjack-console-driver.module';
@@ -31,19 +30,17 @@ describe(LumberjackConsoleDriver.name, () => {
 
     const [_driver] = (resolveDependency(lumberjackLogDriverToken) as unknown) as LumberjackLogDriver[];
     driver = _driver as LumberjackConsoleDriver;
+    logFactory = resolveDependency(LumberjackLogFactory);
     spyLogger = resolveDependency(lumberjackConsoleToken) as SpyConsole;
   });
 
   let driver: LumberjackConsoleDriver;
+  let logFactory: LumberjackLogFactory;
   let spyLogger: SpyConsole;
 
   it("logs the critical level to the console's error channel", () => {
     const expectedMessage = LumberjackLevel.Critical;
-    const expectedLog = new LumberjackLogBuilder(
-      resolveDependency(LumberjackTimeService),
-      LumberjackLevel.Critical,
-      expectedMessage
-    ).build();
+    const expectedLog = logFactory.createCriticalLog(expectedMessage).build();
 
     driver.logCritical({ formattedLog: expectedMessage, log: expectedLog });
 
@@ -53,11 +50,7 @@ describe(LumberjackConsoleDriver.name, () => {
 
   it("logs the debug level to the console's debug channel", () => {
     const expectedMessage = LumberjackLevel.Debug;
-    const expectedLog = new LumberjackLogBuilder(
-      resolveDependency(LumberjackTimeService),
-      LumberjackLevel.Debug,
-      expectedMessage
-    ).build();
+    const expectedLog = logFactory.createDebugLog(expectedMessage).build();
 
     driver.logDebug({ formattedLog: expectedMessage, log: expectedLog });
 
@@ -67,11 +60,7 @@ describe(LumberjackConsoleDriver.name, () => {
 
   it("logs the error level to the console's error channel", () => {
     const expectedMessage = LumberjackLevel.Error;
-    const expectedLog = new LumberjackLogBuilder(
-      resolveDependency(LumberjackTimeService),
-      LumberjackLevel.Error,
-      expectedMessage
-    ).build();
+    const expectedLog = logFactory.createErrorLog(expectedMessage).build();
 
     driver.logError({ formattedLog: expectedMessage, log: expectedLog });
 
@@ -81,11 +70,7 @@ describe(LumberjackConsoleDriver.name, () => {
 
   it("logs the info level to the console's info channel", () => {
     const expectedMessage = LumberjackLevel.Info;
-    const expectedLog = new LumberjackLogBuilder(
-      resolveDependency(LumberjackTimeService),
-      LumberjackLevel.Info,
-      expectedMessage
-    ).build();
+    const expectedLog = logFactory.createInfoLog(expectedMessage).build();
 
     driver.logInfo({ formattedLog: expectedMessage, log: expectedLog });
 
@@ -95,11 +80,7 @@ describe(LumberjackConsoleDriver.name, () => {
 
   it("logs the trace level to the console's trace channel", () => {
     const expectedMessage = LumberjackLevel.Trace;
-    const expectedLog = new LumberjackLogBuilder(
-      resolveDependency(LumberjackTimeService),
-      LumberjackLevel.Trace,
-      expectedMessage
-    ).build();
+    const expectedLog = logFactory.createTraceLog(expectedMessage).build();
 
     driver.logTrace({ formattedLog: expectedMessage, log: expectedLog });
 
@@ -109,11 +90,7 @@ describe(LumberjackConsoleDriver.name, () => {
 
   it("logs the warning level to the console's warn channel", () => {
     const expectedMessage = LumberjackLevel.Warning;
-    const expectedLog = new LumberjackLogBuilder(
-      resolveDependency(LumberjackTimeService),
-      LumberjackLevel.Warning,
-      expectedMessage
-    ).build();
+    const expectedLog = logFactory.createWarningLog(expectedMessage).build();
 
     driver.logWarning({ formattedLog: expectedMessage, log: expectedLog });
 

--- a/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
@@ -4,12 +4,11 @@ import { TestBed } from '@angular/core/testing';
 import { FakeTimeService, resolveDependency } from '@internal/test-util';
 
 import { LumberjackModule } from '../configuration/lumberjack.module';
-import { LumberjackLevel } from '../logs/lumberjack-level';
 import { LumberjackLogPayload } from '../logs/lumberjack-log-payload';
 import { LumberjackLog } from '../logs/lumberjack.log';
 import { LumberjackTimeService } from '../time/lumberjack-time.service';
 
-import { LumberjackLogBuilder } from './lumberjack-log.builder';
+import { LumberjackLogFactory } from './lumberjack-log-factory';
 import { LumberjackService } from './lumberjack.service';
 import { ScopedLumberjackLogger } from './scoped-lumberjack-logger.service';
 
@@ -38,10 +37,12 @@ describe(ScopedLumberjackLogger.name, () => {
     const fakeTime = resolveDependency(LumberjackTimeService) as FakeTimeService;
     fakeTime.setTime(fakeDate);
     logger = resolveDependency(TestLogger);
+    logFactory = resolveDependency(LumberjackLogFactory);
     const lumberjack = resolveDependency(LumberjackService);
     lumberjackLogSpy = jest.spyOn(lumberjack, 'log');
   });
 
+  let logFactory: LumberjackLogFactory;
   let logger: TestLogger;
   let lumberjackLogSpy: jest.SpyInstance<void, [LumberjackLog<void | LumberjackLogPayload>]>;
 
@@ -49,65 +50,41 @@ describe(ScopedLumberjackLogger.name, () => {
     logger.criticalLogger();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(
-      new LumberjackLogBuilder(resolveDependency(LumberjackTimeService), LumberjackLevel.Critical, '')
-        .withScope(logger.scope)
-        .build()
-    );
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createCriticalLog('').withScope(logger.scope).build());
   });
 
   it('can create a debug logger', () => {
     logger.debugLogger();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(
-      new LumberjackLogBuilder(resolveDependency(LumberjackTimeService), LumberjackLevel.Debug, '')
-        .withScope(logger.scope)
-        .build()
-    );
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createDebugLog('').withScope(logger.scope).build());
   });
 
   it('can create an error logger', () => {
     logger.errorLogger();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(
-      new LumberjackLogBuilder(resolveDependency(LumberjackTimeService), LumberjackLevel.Error, '')
-        .withScope(logger.scope)
-        .build()
-    );
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createErrorLog('').withScope(logger.scope).build());
   });
 
   it('can create an info logger', () => {
     logger.infoLogger();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(
-      new LumberjackLogBuilder(resolveDependency(LumberjackTimeService), LumberjackLevel.Info, '')
-        .withScope(logger.scope)
-        .build()
-    );
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createInfoLog('').withScope(logger.scope).build());
   });
 
   it('can create a trace logger', () => {
     logger.traceLogger();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(
-      new LumberjackLogBuilder(resolveDependency(LumberjackTimeService), LumberjackLevel.Trace, '')
-        .withScope(logger.scope)
-        .build()
-    );
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createTraceLog('').withScope(logger.scope).build());
   });
 
   it('can create a warning logger', () => {
     logger.warningLogger();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(
-      new LumberjackLogBuilder(resolveDependency(LumberjackTimeService), LumberjackLevel.Warning, '')
-        .withScope(logger.scope)
-        .build()
-    );
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createWarningLog('').withScope(logger.scope).build());
   });
 });

--- a/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
@@ -39,7 +39,7 @@ describe(ScopedLumberjackLogger.name, () => {
     logger = resolveDependency(TestLogger);
     logFactory = resolveDependency(LumberjackLogFactory);
     const lumberjack = resolveDependency(LumberjackService);
-    lumberjackLogSpy = jest.spyOn(lumberjack, 'log');
+    lumberjackLogSpy = jest.spyOn(lumberjack, 'log').mockImplementation(() => {});
   });
 
   let logFactory: LumberjackLogFactory;

--- a/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
@@ -28,16 +28,12 @@ export class TestLogger extends ScopedLumberjackLogger {
   warning = (message: string): void => this.createWarningLogger(message).build().call(this);
 }
 
-const fakeDate = new Date('2020-02-02T02:02:02.000Z');
-
 describe(ScopedLumberjackLogger.name, () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [LumberjackModule.forRoot()],
       providers: [{ provide: LumberjackTimeService, useClass: FakeTimeService }],
     });
-    const fakeTime = resolveDependency(LumberjackTimeService) as FakeTimeService;
-    fakeTime.setTime(fakeDate);
     logger = resolveDependency(TestLogger);
     logFactory = resolveDependency(LumberjackLogFactory);
     const lumberjack = resolveDependency(LumberjackService);

--- a/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
@@ -18,12 +18,12 @@ import { ScopedLumberjackLogger } from './scoped-lumberjack-logger.service';
 export class TestLogger extends ScopedLumberjackLogger {
   readonly scope = 'Test';
 
-  criticalLogger = this.createCriticalLogger('').build();
-  debugLogger = this.createDebugLogger('').build();
-  errorLogger = this.createErrorLogger('').build();
-  infoLogger = this.createInfoLogger('').build();
-  traceLogger = this.createTraceLogger('').build();
-  warningLogger = this.createWarningLogger('').build();
+  critical = this.createCriticalLogger('').build();
+  debug = this.createDebugLogger('').build();
+  error = this.createErrorLogger('').build();
+  info = this.createInfoLogger('').build();
+  trace = this.createTraceLogger('').build();
+  warning = this.createWarningLogger('').build();
 }
 
 const fakeDate = new Date('2020-02-02T02:02:02.000Z');
@@ -47,42 +47,42 @@ describe(ScopedLumberjackLogger.name, () => {
   let lumberjackLogSpy: jest.SpyInstance<void, [LumberjackLog<void | LumberjackLogPayload>]>;
 
   it('can create a critical logger', () => {
-    logger.criticalLogger();
+    logger.critical();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
     expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createCriticalLog('').withScope(logger.scope).build());
   });
 
   it('can create a debug logger', () => {
-    logger.debugLogger();
+    logger.debug();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
     expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createDebugLog('').withScope(logger.scope).build());
   });
 
   it('can create an error logger', () => {
-    logger.errorLogger();
+    logger.error();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
     expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createErrorLog('').withScope(logger.scope).build());
   });
 
   it('can create an info logger', () => {
-    logger.infoLogger();
+    logger.info();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
     expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createInfoLog('').withScope(logger.scope).build());
   });
 
   it('can create a trace logger', () => {
-    logger.traceLogger();
+    logger.trace();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
     expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createTraceLog('').withScope(logger.scope).build());
   });
 
   it('can create a warning logger', () => {
-    logger.warningLogger();
+    logger.warning();
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
     expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createWarningLog('').withScope(logger.scope).build());

--- a/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
+++ b/libs/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.spec.ts
@@ -18,12 +18,14 @@ import { ScopedLumberjackLogger } from './scoped-lumberjack-logger.service';
 export class TestLogger extends ScopedLumberjackLogger {
   readonly scope = 'Test';
 
-  critical = this.createCriticalLogger('').build();
-  debug = this.createDebugLogger('').build();
-  error = this.createErrorLogger('').build();
-  info = this.createInfoLogger('').build();
-  trace = this.createTraceLogger('').build();
-  warning = this.createWarningLogger('').build();
+  critical = (message: string): void => this.createCriticalLogger(message).build().call(this);
+
+  debug = (message: string): void => this.createDebugLogger(message).build().call(this);
+
+  error = (message: string): void => this.createErrorLogger(message).build().call(this);
+  info = (message: string): void => this.createInfoLogger(message).build().call(this);
+  trace = (message: string): void => this.createTraceLogger(message).build().call(this);
+  warning = (message: string): void => this.createWarningLogger(message).build().call(this);
 }
 
 const fakeDate = new Date('2020-02-02T02:02:02.000Z');
@@ -47,44 +49,68 @@ describe(ScopedLumberjackLogger.name, () => {
   let lumberjackLogSpy: jest.SpyInstance<void, [LumberjackLog<void | LumberjackLogPayload>]>;
 
   it('can create a critical logger', () => {
-    logger.critical();
+    const testMessage = 'Critical message';
+
+    logger.critical(testMessage);
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createCriticalLog('').withScope(logger.scope).build());
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(
+      logFactory.createCriticalLog(testMessage).withScope(logger.scope).build()
+    );
   });
 
   it('can create a debug logger', () => {
-    logger.debug();
+    const testMessage = 'Debug message';
+
+    logger.debug(testMessage);
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createDebugLog('').withScope(logger.scope).build());
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(
+      logFactory.createDebugLog(testMessage).withScope(logger.scope).build()
+    );
   });
 
   it('can create an error logger', () => {
-    logger.error();
+    const testMessage = 'Error message';
+
+    logger.error(testMessage);
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createErrorLog('').withScope(logger.scope).build());
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(
+      logFactory.createErrorLog(testMessage).withScope(logger.scope).build()
+    );
   });
 
   it('can create an info logger', () => {
-    logger.info();
+    const testMessage = 'Info message';
+
+    logger.info(testMessage);
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createInfoLog('').withScope(logger.scope).build());
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(
+      logFactory.createInfoLog(testMessage).withScope(logger.scope).build()
+    );
   });
 
   it('can create a trace logger', () => {
-    logger.trace();
+    const testMessage = 'Trace message';
+
+    logger.trace(testMessage);
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createTraceLog('').withScope(logger.scope).build());
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(
+      logFactory.createTraceLog(testMessage).withScope(logger.scope).build()
+    );
   });
 
   it('can create a warning logger', () => {
-    logger.warning();
+    const testMessage = 'Warning message';
+
+    logger.warning(testMessage);
 
     expect(lumberjackLogSpy).toHaveBeenCalledTimes(1);
-    expect(lumberjackLogSpy).toHaveBeenCalledWith(logFactory.createWarningLog('').withScope(logger.scope).build());
+    expect(lumberjackLogSpy).toHaveBeenCalledWith(
+      logFactory.createWarningLog(testMessage).withScope(logger.scope).build()
+    );
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Test refactoring
```

## What is the current behavior?
`LumberjackLogBuilder` is used in a range of tests. The test must pass it `LumberjackTimeService` and the order of parameters is not apparent.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Most tests using `LumberjackLogBuilder` are refactored to using `LumberjackLogFactory.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
`ScopedLumberjackLogger` test suite:
- Add parameterized loggers.
- Prevent side effects from logging.