### PR TITLE
ci: add delete-path-alias steps for schematics-e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,9 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-angular-${{ matrix.angular-version }}-yarn-
             ${{ runner.os }}-node-${{ matrix.node-version }}-angular-
       - run: yarn install
+      - run: yarn delete-path-alias @ngworker/lumberjack
+      - run: yarn delete-path-alias @ngworker/lumberjack/console-driver
+      - run: yarn delete-path-alias @ngworker/lumberjack/http-driver
       - uses: actions/download-artifact@v2
         with:
           name: lumberjack-package


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Local TypeScript path mappings are not deleted in the `schematics-e2e` CI job. Uncertainty about which package it's using. It has to use the package from the build artifact.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Local TypeScript path mappings are deleted in the `schematics-e2e` CI job. It's definitely using the package from the build artifact.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
