### PR TITLE
fix: export root Angular modules

### DIFF
--- a/libs/internal/test-util/src/index.ts
+++ b/libs/internal/test-util/src/index.ts
@@ -10,6 +10,7 @@ export * from './lib/angular/resolve-dependency';
 export * from './lib/error-throwing-driver/error-throwing-driver.config';
 export * from './lib/error-throwing-driver/error-throwing-driver.module';
 export * from './lib/error-throwing-driver/error-throwing-driver.options';
+export * from './lib/error-throwing-driver/error-throwing-driver-root.module';
 export * from './lib/error-throwing-driver/error-throwing.driver';
 
 // Functions
@@ -20,14 +21,17 @@ export * from './lib/logs';
 
 // No-op driver
 export * from './lib/noop-driver/noop-driver.module';
+export * from './lib/noop-driver/noop-driver-root.module';
 export * from './lib/noop-driver/noop.driver';
 
 // Spy driver
 export * from './lib/spy-driver/spy-driver.module';
+export * from './lib/spy-driver/spy-driver-root.module';
 export * from './lib/spy-driver/spy.driver';
 
 // Object driver
 export * from './lib/object-driver/object-driver.module';
+export * from './lib/object-driver/object-driver-root.module';
 export * from './lib/object-driver/object.driver';
 export * from './lib/object-driver/object.service';
 export * from './lib/object-driver/object.payload';

--- a/libs/ngworker/lumberjack/console-driver/src/configuration-api.spec.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/configuration-api.spec.ts
@@ -1,11 +1,17 @@
 import { isClass } from '@internal/test-util';
 
-import { LumberjackConsoleDriverModule } from './index';
+import { LumberjackConsoleDriverModule, LumberjackConsoleDriverRootModule } from './index';
 
 describe('Configuration API', () => {
   describe('Angular modules', () => {
     it(`exposes ${LumberjackConsoleDriverModule.name}`, () => {
       const sut = LumberjackConsoleDriverModule;
+
+      expect(isClass(sut)).toBeTruthy();
+    });
+
+    it(`exposes ${LumberjackConsoleDriverRootModule.name}`, () => {
+      const sut = LumberjackConsoleDriverRootModule;
 
       expect(isClass(sut)).toBeTruthy();
     });

--- a/libs/ngworker/lumberjack/console-driver/src/index.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/index.ts
@@ -4,6 +4,7 @@
 
 // Configuration
 export { LumberjackConsoleDriverModule } from './lib/configuration/lumberjack-console-driver.module';
+export { LumberjackConsoleDriverRootModule } from './lib/configuration/lumberjack-console-driver-root.module';
 
 // Console
 export { LumberjackConsole } from './lib/console/lumberjack-console';

--- a/libs/ngworker/lumberjack/console-driver/src/lib/configuration/lumberjack-console-driver-root.module.ts
+++ b/libs/ngworker/lumberjack/console-driver/src/lib/configuration/lumberjack-console-driver-root.module.ts
@@ -24,6 +24,9 @@ export function consoleDriverFactory(
   return new LumberjackConsoleDriver(fullConfig, console);
 }
 
+/**
+ * Do not import directly. Use `LumberjackConsoleDriverModule.forRoot`.
+ */
 @NgModule({
   providers: [
     {

--- a/libs/ngworker/lumberjack/http-driver/src/configuration-api.spec.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/configuration-api.spec.ts
@@ -5,6 +5,7 @@ import {
   LumberjackHttpDriverModule,
   LumberjackHttpDriverOptions,
   LumberjackHttpDriverRetryOptions,
+  LumberjackHttpDriverRootModule,
 } from './index';
 
 describe('Configuration API', () => {
@@ -33,6 +34,12 @@ describe('Configuration API', () => {
   describe('Angular modules', () => {
     it(`exposes ${LumberjackHttpDriverModule.name}`, () => {
       const sut = LumberjackHttpDriverModule;
+
+      expect(isClass(sut)).toBeTruthy();
+    });
+
+    it(`exposes ${LumberjackHttpDriverRootModule.name}`, () => {
+      const sut = LumberjackHttpDriverRootModule;
 
       expect(isClass(sut)).toBeTruthy();
     });

--- a/libs/ngworker/lumberjack/http-driver/src/index.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/index.ts
@@ -7,6 +7,7 @@ export { LumberjackHttpDriverRetryOptions } from './lib/configuration/lumberjack
 export { LumberjackHttpDriverConfig } from './lib/configuration/lumberjack-http-driver.config';
 export { LumberjackHttpDriverModule } from './lib/configuration/lumberjack-http-driver.module';
 export { LumberjackHttpDriverOptions } from './lib/configuration/lumberjack-http-driver.options';
+export { LumberjackHttpDriverRootModule } from './lib/configuration/lumberjack-http-driver-root.module';
 
 // Log drivers
 export { LumberjackHttpDriver } from './lib/log-drivers/lumberjack-http.driver';

--- a/libs/ngworker/lumberjack/http-driver/src/lib/configuration/lumberjack-http-driver-root.module.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/lib/configuration/lumberjack-http-driver-root.module.ts
@@ -26,6 +26,9 @@ export function httpDriverFactory(
   return new LumberjackHttpDriver(http, config, ngZone);
 }
 
+/**
+ * Do not import directly. Use `LumberjackHttpDriverModule.forRoot`.
+ */
 @NgModule({
   imports: [HttpClientModule],
   providers: [

--- a/libs/ngworker/lumberjack/src/configuration-api.spec.ts
+++ b/libs/ngworker/lumberjack/src/configuration-api.spec.ts
@@ -10,6 +10,7 @@ import {
   lumberjackLogDriverConfigToken,
   LumberjackModule,
   LumberjackOptions,
+  LumberjackRootModule,
 } from './index';
 
 describe('Configuration API', () => {
@@ -44,6 +45,12 @@ describe('Configuration API', () => {
   describe('Angular modules', () => {
     it(`exposes ${LumberjackModule.name}`, () => {
       const sut = LumberjackModule;
+
+      expect(isClass(sut)).toBeTruthy();
+    });
+
+    it(`exposes ${LumberjackRootModule.name}`, () => {
+      const sut = LumberjackRootModule;
 
       expect(isClass(sut)).toBeTruthy();
     });

--- a/libs/ngworker/lumberjack/src/index.ts
+++ b/libs/ngworker/lumberjack/src/index.ts
@@ -10,6 +10,7 @@ export { lumberjackLogDriverConfigToken } from './lib/configuration/lumberjack-l
 export { LumberjackConfig } from './lib/configuration/lumberjack.config';
 export { LumberjackModule } from './lib/configuration/lumberjack.module';
 export { LumberjackOptions } from './lib/configuration/lumberjack.options';
+export { LumberjackRootModule } from './lib/configuration/lumberjack-root.module';
 
 // Log drivers
 export { LumberjackLogDriver } from './lib/log-drivers/lumberjack-log-driver';

--- a/libs/ngworker/lumberjack/src/lib/configuration/lumberjack-root.module.ts
+++ b/libs/ngworker/lumberjack/src/lib/configuration/lumberjack-root.module.ts
@@ -26,6 +26,9 @@ export function logDriverConfigFactory({ levels }: LumberjackConfig): Omit<Lumbe
   };
 }
 
+/**
+ * Do not import directly. Use `LumberjackModule.forRoot`.
+ */
 @NgModule({
   providers: [
     {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Root Angular modules such as `LumberjackRootModule` are not exposed in the public APIs. This causes compilation errors in some development environments, for example:
- Certain versions of Nx 11.0.x
- When using Angular Linker (requires Angular CLI >=11.1 and a Lumberjack bundle with partial Ivy compilation)
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The following Angular modules are exposed in the public APIs:
- `LumberjackRootModule` (`@ngworker/lumberjack`)
- `LumberjackConsoleDriverRootModule` (`@ngworker/lumberjack/console-driver`)
- `LumberjackHttpDriverRootModule` (`@ngworker/lumberjack/http-driver`)

Note that root Angular modules should not be directly imported. For example, `LumberjackRootModule` should only be imported through `LumberjackModule.forRoot`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
