### PR TITLE
refactor(http-driver): use preferred subscribe signature internally

### DIFF
--- a/libs/ngworker/lumberjack/http-driver/src/lib/log-drivers/lumberjack-http.driver.ts
+++ b/libs/ngworker/lumberjack/http-driver/src/lib/log-drivers/lumberjack-http.driver.ts
@@ -97,7 +97,9 @@ export class LumberjackHttpDriver<TPayload extends LumberjackLogPayload | void =
       this.http
         .post<void>(storeUrl, httpLog)
         .pipe(retryWithDelay(retryOptions.maxRetries, retryOptions.delayMs))
-        .subscribe();
+        .subscribe(() => {
+          // No-op
+        });
     });
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
[The SonarCloud gods are angry](https://sonarcloud.io/project/issues?id=ngworker_lumberjack&open=AXjx4aW2bw9bT6FFaPqS&resolved=false&types=CODE_SMELL) that we're using a deprecated signature of `Observable#subscribe`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Hopefully, this will please the SonarCloud gods.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
