### PR TITLE
feat(chore): set module compiler option to es2020

### DIFF
--- a/libs/ngworker/lumberjack/tsconfig.lib.json
+++ b/libs/ngworker/lumberjack/tsconfig.lib.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "../../../out-tsc/lib",
     "target": "es2015",
+    "module": "es2020",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Couldn't find any issue related to this, hence pasting backlog card here. Should I create a new issue first and then link it here?
Issue Number: https://github.com/ngworker/lumberjack/projects/1#card-50958521

## What is the new behavior?
As per the migration update guide from [angular](https://angular.io/guide/migration-update-module-and-target-compiler-options):

### Why "es2020" instead of "esnext"?
In TypeScript 3.9, the behavior of the TypeScript compiler controlled by module is the same with both "esnext" and "es2020" values. This behavior can change in the future, because the "esnext" option could evolve in a backwards incompatible ways, resulting in build-time or run-time errors during a TypeScript update. As a result, code can become unstable. Using the "es2020" option mitigates this risk.
https://angular.io/guide/migration-update-module-and-target-compiler-options#why-es2020-instead-of-esnext

### Why is this migration necessary?
This migration provides improvements to the long-term supportability of projects by updating the projects to use recommended best practice compilation options.
https://angular.io/guide/migration-update-module-and-target-compiler-options#why-is-this-migration-necessary


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
