### PR TITLE
fix: always run report commands for sonar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
       # build: 2 tasks assigned at a time, 1 task per vCPU
       # e2e: 1 task assigned at a time, 1 task total
       parallel-commands-on-agents: |
-        yarn nx affected --target=lint --configuration=report --parallel=2 --max-warnings=0
-        yarn nx affected --target=test --configuration=coverage --parallel=1 --max-workers=2
+        yarn nx run-many --all --target=lint --configuration=report --parallel=2 --max-warnings=0
+        yarn nx run-many --all --target=test --configuration=coverage --parallel=1 --max-workers=2
         yarn nx affected --target=build --parallel=2
         yarn nx affected --target=e2e --parallel=1
       # Commands run sequentially on this DTE coordinator after parallel jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,10 @@ jobs:
         uses: ./.github/actions/setup
       # Uses the cache generated in the distributed step (Needed for the sonar eslint reports).
       - name: Lint with reports
-        run: yarn nx affected --target=lint --configuration=report --parallel=2 --max-warnings=0
+        run: yarn nx run-many --all --target=lint --configuration=report --parallel=2 --max-warnings=0
         # Uses the cache generated in the distributed step (Needed for the sonar jest coverage reports).
       - name: Tests with coverage
-        run: yarn nx affected --target=test --configuration=coverage --parallel=1 --max-workers=2
+        run: yarn nx run-many --all --target=test --configuration=coverage --parallel=1 --max-workers=2
 
       - name: Configure Sonar report paths
         run: yarn configure-sonar-report-paths


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Sonar is not tracking any files. There is no code coverage at all.

## What is the new behavior?

We always generate the reports for lints and test to feed them to sonar.

![Screenshot 2023-02-15 at 10 39 33](https://user-images.githubusercontent.com/9338604/219043190-8826c4d5-930f-4019-8962-738d1c520e50.jpg)



## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
