### PR TITLE
docs: Updated inject example to show constructor usage

### DIFF
--- a/packages/docs/lumberjack-docs-app/docs/usage.md
+++ b/packages/docs/lumberjack-docs-app/docs/usage.md
@@ -91,7 +91,7 @@ import { LumberjackService } from '@ngworker/lumberjack';
   // (...)
 })
 export class MyComponent implements OnInit {
-  readonly #lumberjack = inject(LumberjackService);
+  constructor(private readonly lumberjack: LumberjackService) {}
 
   // (...)
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Duplicate example in https://ngworker.github.io/lumberjack/docs/usage#using-the-lumberjackservice where both show usage with `inject()`.

Issue Number: N/A

## What is the new behavior?
Updated the first example to use the constructor for injection.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Fixes #163