### PR TITLE
chore: fix the permission to enable automatic releases

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,12 +2,28 @@ name: Setup
 
 description: Setup Node.js, cache and install dependencies
 
+inputs:
+  git_bot_token:
+    description: Git Bot token used to push to protected branches because github token can't
+    required: false
+
 runs:
   using: composite
   steps:
+    - name: Checkout all commits
+      uses: actions/checkout@v3
+      with:
+        token: ${{ inputs.git_bot_token || github.token }}
+        fetch-depth: 0
+
     # Needed for nx affected command, it set the BASE and HEAD env variables
     - name: Derive appropriate SHAs for base and head for `nx affected` commands
       uses: nrwl/nx-set-shas@v3
+
+    # Set ups the git user for the Changelog commit
+    - name: Setup git user to "🤖 NgWorker Bot"
+      shell: bash
+      run: git config user.email "-" && git config user.name "🤖 NgWorker Bot"
 
     - name: Determine Node.js version
       id: node_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,16 +35,28 @@ jobs:
           fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
-
-      # Set ups the git user for the Changelog commit
-      - name: Setup git user to "🤖 NgWorker Bot"
-        shell: bash
-        run: git config user.email "-" && git config user.name "🤖 NgWorker Bot"
+        with:
+          git_bot_token: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: Release @ngworker/lumberjack
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         # Generates the changelog commit and tags and pushes them to Github.
         # Use two post actions to Create a release in Github and for Publishing the package to NPM
+        shell: bash
         run: npx nx version ngworker-lumberjack --releaseAs=${{ github.event.inputs.release_as }}
+
+      # Needed if we want to automize multiple releases with the affected commands.
+      - name: Tag last-release
+        shell: bash
+        run: git tag -f last-release
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          branch: ${{ github.ref }}
+          force: true
+          tags: true

--- a/packages/ngworker/lumberjack/project.json
+++ b/packages/ngworker/lumberjack/project.json
@@ -91,7 +91,7 @@
         "preset": "conventional",
         "tagPrefix": "v",
         "noVerify": true,
-        "push": true,
+        "push": false,
         "preid": "beta",
         "syncVersions": false,
         "commitMessageFormat": "release(${projectName}): 🎸 cut release to ${version}",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, we cannot release new versions of Lumberjack using the `release` Github Action because we haven't correctly configure the NPM and Github access tokens

## What is the new behavior?

We can now automatically release to NPM and GitHub using the `release` Github Action.