### PR TITLE
fix: manually set @angular/platform-browser as optional peerDependency

### DIFF
--- a/packages/ngworker/lumberjack/package.json
+++ b/packages/ngworker/lumberjack/package.json
@@ -39,10 +39,14 @@
   "peerDependencies": {
     "@angular/core": ">= 15.0.1",
     "@angular/common": ">= 15.0.1",
+    "@angular/platform-browser": ">= 15.0.1",
     "rxjs": "~7.5.0"
   },
   "peerDependenciesMeta": {
     "@angular/common": {
+      "optional": true
+    },
+    "@angular/platform-browser": {
       "optional": true
     },
     "rxjs": {

--- a/packages/ngworker/lumberjack/project.json
+++ b/packages/ngworker/lumberjack/project.json
@@ -109,7 +109,6 @@
       "executor": "ngx-deploy-npm:deploy",
       "options": {
         "access": "public",
-        "tag": "next",
         "distFolderPath": "dist/packages/ngworker/lumberjack"
       }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`@angular/platform-browser` is being added automatically as a peer dependency to the package.json on the build but is not treated manually.

Closes: #170 

## What is the new behavior?

We manually set `@angular/platform-browser` as an optional peerDependency on the package.json.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```