### PR TITLE
fix: make rxjs version dynamic to support newest versions of Angular

### DIFF
--- a/packages/ngworker/lumberjack/package.json
+++ b/packages/ngworker/lumberjack/package.json
@@ -40,7 +40,7 @@
     "@angular/core": ">= 15.0.1",
     "@angular/common": ">= 15.0.1",
     "@angular/platform-browser": ">= 15.0.1",
-    "rxjs": "~7.5.0"
+    "rxjs": ">= 7.5.0 < 8.0.0"
   },
   "peerDependenciesMeta": {
     "@angular/common": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

RxJS version is fixed at version `7.5.0`, which makes it incompatible with the newest version of Angular.

## What is the new behavior?

RxJS peerDependency is set to support versions between `>= 7.5.0` and `< 8.0.0`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
