### PR TITLE
feat!: add support for string literals and deprecate enums

### DIFF
--- a/packages/docs/lumberjack-docs-app/docs/log-drivers/http-driver.md
+++ b/packages/docs/lumberjack-docs-app/docs/log-drivers/http-driver.md
@@ -244,7 +244,7 @@ Classic:
     LumberjackModule.forRoot(),
     LumberjackConsoleDriverModule.forRoot(),
     LumberjackHttpDriverModule.forRoot({
-      levels: [LumberjackLevel.Error],
+      levels: ['error'],
       origin: 'ForestApp',
       retryOptions: { maxRetries: 5, delayMs: 250 },
       storeUrl: '/api/logs',
@@ -272,7 +272,7 @@ or
   providers: [
     ...,
     provideLumberjack(), provideLumberjackConsoleDriver(), provideLumberjackHttpDriver(withHttpConfig({
-      levels: [LumberjackLevel.Error],
+      levels: ['error'],
       origin: 'ForestApp',
       retryOptions: { maxRetries: 5, delayMs: 250 },
       storeUrl: '/api/logs',

--- a/packages/docs/lumberjack-docs-app/docs/log-drivers/log-drivers.md
+++ b/packages/docs/lumberjack-docs-app/docs/log-drivers/log-drivers.md
@@ -52,18 +52,18 @@ levels for the HTTP driver as seen in the following example.
 
 ```ts
 import { NgModule } from '@angular/core';
-import { LumberjackLevel, LumberjackModule } from '@ngworker/lumberjack';
+import { Level as LumberjackLevel, LumberjackModule } from '@ngworker/lumberjack';
 import { LumberjackConsoleDriverModule } from '@ngworker/lumberjack/console-driver';
 import { LumberjackHttpDriverModule } from '@ngworker/lumberjack/http-driver';
 
 @NgModule({
   imports: [
     LumberjackModule.forRoot({
-      levels: [LumberjackLevel.Verbose],
+      levels: ['verbose'],
     }),
     LumberjackConsoleDriverModule.forRoot(),
     LumberjackHttpDriverModule.forRoot({
-      levels: [LumberjackLevel.Critical, LumberjackLevel.Error],
+      levels: ['critical', 'error'],
       origin: 'ForestApp',
       storeUrl: '/api/logs',
       retryOptions: { maxRetries: 5, delayMs: 250 },
@@ -80,7 +80,7 @@ Or use the standalone version of the API
 ```ts
 import { bootstrapApplication } from '@angular/platform-browser';
 
-import { LumberjackLevel, provideLumberjack } from '@ngworker/lumberjack';
+import { Level as LumberjackLevel, provideLumberjack } from '@ngworker/lumberjack';
 import { provideLumberjackConsoleDriver } from '@ngworker/lumberjack/console-driver';
 import { provideLumberjackHttpDriver, withHttpConfig } from '@ngworker/lumberjack/http-driver';
 
@@ -92,7 +92,7 @@ bootstrapApplication(AppComponent, {
     provideLumberjackConsoleDriver(),
     provideLumberjackHttpDriver(
       withHttpConfig({
-        levels: [LumberjackLevel.Critical, LumberjackLevel.Error],
+        levels: ['critical', 'error'],
         origin: 'ForestApp',
         storeUrl: '/api/logs',
         retryOptions: { maxRetries: 5, delayMs: 250 },

--- a/packages/internal/test-util/src/lib/error-throwing-driver/error-throwing.driver.spec.ts
+++ b/packages/internal/test-util/src/lib/error-throwing-driver/error-throwing.driver.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import {
+  LogLevel,
   LumberjackLevel,
   LumberjackLogDriver,
   LumberjackLogDriverLog,
@@ -36,7 +37,13 @@ describe(ErrorThrowingDriver.name, () => {
     [LumberjackLevel.Info, (driver) => driver.logInfo],
     [LumberjackLevel.Trace, (driver) => driver.logTrace],
     [LumberjackLevel.Warning, (driver) => driver.logWarning],
-  ] as ReadonlyArray<[LumberjackLogLevel, (driver: LumberjackLogDriver) => (driverLog: LumberjackLogDriverLog) => void]>)(
+    ['critical', (driver) => driver.logCritical],
+    ['debug', (driver) => driver.logDebug],
+    ['error', (driver) => driver.logError],
+    ['info', (driver) => driver.logInfo],
+    ['trace', (driver) => driver.logTrace],
+    ['warn', (driver) => driver.logWarning],
+  ] as ReadonlyArray<[LumberjackLogLevel | LogLevel, (driver: LumberjackLogDriver) => (driverLog: LumberjackLogDriverLog) => void]>)(
     `implements a spy when using the %s log level`,
     (logLevel, logMethod) => {
       it('throws an error on first log when the default log driver configuration is used', () => {

--- a/packages/internal/test-util/src/lib/logs/driver-log-creators.ts
+++ b/packages/internal/test-util/src/lib/logs/driver-log-creators.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import {
-  LumberjackLevel,
+  LogLevel,
   LumberjackLogDriverLog,
   LumberjackLogLevel,
   LumberjackLogPayload,
@@ -10,7 +10,7 @@ import {
 
 export const createDriverLog = <TPayload extends LumberjackLogPayload | void = void>(
   formattedLog: string,
-  level: LumberjackLogLevel,
+  level: LumberjackLogLevel | LogLevel,
   message = '',
   scope = 'Test',
   payload?: TPayload
@@ -30,39 +30,39 @@ export const createCriticalDriverLog = <TPayload extends LumberjackLogPayload | 
   message?: string,
   scope?: string,
   payload?: TPayload
-): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, LumberjackLevel.Critical, message, scope, payload);
+): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, 'critical', message, scope, payload);
 
 export const createDebugDriverLog = <TPayload extends LumberjackLogPayload | void = void>(
   formattedLog: string,
   message?: string,
   scope?: string,
   payload?: TPayload
-): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, LumberjackLevel.Debug, message, scope, payload);
+): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, 'debug', message, scope, payload);
 
 export const createErrorDriverLog = <TPayload extends LumberjackLogPayload | void = void>(
   formattedLog: string,
   message?: string,
   scope?: string,
   payload?: TPayload
-): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, LumberjackLevel.Error, message, scope, payload);
+): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, 'error', message, scope, payload);
 
 export const createInfoDriverLog = <TPayload extends LumberjackLogPayload | void = void>(
   formattedLog: string,
   message?: string,
   scope?: string,
   payload?: TPayload
-): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, LumberjackLevel.Info, message, scope, payload);
+): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, 'info', message, scope, payload);
 
 export const createTraceDriverLog = <TPayload extends LumberjackLogPayload | void = void>(
   formattedLog: string,
   message?: string,
   scope?: string,
   payload?: TPayload
-): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, LumberjackLevel.Trace, message, scope, payload);
+): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, 'trace', message, scope, payload);
 
 export const createWarningDriverLog = <TPayload extends LumberjackLogPayload | void = void>(
   formattedLog: string,
   message?: string,
   scope?: string,
   payload?: TPayload
-): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, LumberjackLevel.Warning, message, scope, payload);
+): LumberjackLogDriverLog<TPayload> => createDriverLog(formattedLog, 'warn', message, scope, payload);

--- a/packages/internal/test-util/src/lib/object-driver/object.driver.spec.ts
+++ b/packages/internal/test-util/src/lib/object-driver/object.driver.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { createDriverLog, provideObjectDriver } from '@internal/test-util';
 import {
+  LogLevel,
   LumberjackLevel,
   LumberjackLogDriver,
   LumberjackLogDriverLog,
@@ -36,7 +37,13 @@ describe(ObjectDriver.name, () => {
     [LumberjackLevel.Info, (driver) => driver.logInfo, { isWorking: true }],
     [LumberjackLevel.Trace, (driver) => driver.logTrace, { isWorking: false }],
     [LumberjackLevel.Warning, (driver) => driver.logWarning, undefined],
-  ] as ReadonlyArray<[LumberjackLogLevel, (driver: LumberjackLogDriver<ObjectPayload>) => (driverLog: LumberjackLogDriverLog<ObjectPayload>) => void, ObjectPayload | undefined]>)(
+    ['critical', (driver) => driver.logCritical, { isWorking: true }],
+    ['debug', (driver) => driver.logDebug, { isWorking: false }],
+    ['error', (driver) => driver.logError, undefined],
+    ['info', (driver) => driver.logInfo, { isWorking: true }],
+    ['trace', (driver) => driver.logTrace, { isWorking: false }],
+    ['warn', (driver) => driver.logWarning, undefined],
+  ] as ReadonlyArray<[LumberjackLogLevel | LogLevel, (driver: LumberjackLogDriver<ObjectPayload>) => (driverLog: LumberjackLogDriverLog<ObjectPayload>) => void, ObjectPayload | undefined]>)(
     `delegates to ${ObjectService.name} when using the %s log level`,
     (logLevel, logMethod, expectedPayload) => {
       it(`forwards the log payload to the ${ObjectService.prototype.log.name} method`, () => {

--- a/packages/internal/test-util/src/lib/spy-driver/spy.driver.spec.ts
+++ b/packages/internal/test-util/src/lib/spy-driver/spy.driver.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import {
+  LogLevel,
   LumberjackLevel,
   LumberjackLogDriver,
   LumberjackLogDriverLog,
@@ -38,7 +39,7 @@ describe(SpyDriver.name, () => {
     ['info', (driver) => driver.logInfo],
     ['trace', (driver) => driver.logTrace],
     ['warn', (driver) => driver.logWarning],
-  ] as ReadonlyArray<[LumberjackLogLevel, (driver: LumberjackLogDriver<void>) => (driverLog: LumberjackLogDriverLog<void>) => void]>)(
+  ] as ReadonlyArray<[LumberjackLogLevel | LogLevel, (driver: LumberjackLogDriver<void>) => (driverLog: LumberjackLogDriverLog<void>) => void]>)(
     `implements a spy when using the %s log level`,
     (logLevel, logMethod) => {
       it('records calls', () => {

--- a/packages/internal/test-util/src/lib/spy-driver/spy.driver.spec.ts
+++ b/packages/internal/test-util/src/lib/spy-driver/spy.driver.spec.ts
@@ -32,6 +32,12 @@ describe(SpyDriver.name, () => {
     [LumberjackLevel.Info, (driver) => driver.logInfo],
     [LumberjackLevel.Trace, (driver) => driver.logTrace],
     [LumberjackLevel.Warning, (driver) => driver.logWarning],
+    ['critical', (driver) => driver.logCritical],
+    ['debug', (driver) => driver.logDebug],
+    ['error', (driver) => driver.logError],
+    ['info', (driver) => driver.logInfo],
+    ['trace', (driver) => driver.logTrace],
+    ['warn', (driver) => driver.logWarning],
   ] as ReadonlyArray<[LumberjackLogLevel, (driver: LumberjackLogDriver<void>) => (driverLog: LumberjackLogDriverLog<void>) => void]>)(
     `implements a spy when using the %s log level`,
     (logLevel, logMethod) => {

--- a/packages/ngworker/lumberjack/http-driver/README.md
+++ b/packages/ngworker/lumberjack/http-driver/README.md
@@ -234,7 +234,7 @@ Classic:
     LumberjackModule.forRoot(),
     LumberjackConsoleDriverModule.forRoot(),
     LumberjackHttpDriverModule.forRoot({
-      levels: [LumberjackLevel.Error],
+      levels: ['error'],
       origin: 'ForestApp',
       retryOptions: { maxRetries: 5, delayMs: 250 },
       storeUrl: '/api/logs',
@@ -262,7 +262,7 @@ or
   providers: [
     ...,
     provideLumberjack(), provideLumberjackConsoleDriver(), provideLumberjackHttpDriver(withHttpConfig({
-      levels: [LumberjackLevel.Error],
+      levels: ['error'],
       origin: 'ForestApp',
       retryOptions: { maxRetries: 5, delayMs: 250 },
       storeUrl: '/api/logs',

--- a/packages/ngworker/lumberjack/http-driver/src/lib/log-drivers/lumberjack-http.driver.spec.ts
+++ b/packages/ngworker/lumberjack/http-driver/src/lib/log-drivers/lumberjack-http.driver.spec.ts
@@ -4,6 +4,7 @@ import { VERSION } from '@angular/platform-browser';
 
 import { createCriticalDriverLog, createDriverLog, repeatSideEffect } from '@internal/test-util';
 import {
+  LogLevel,
   LumberjackLevel,
   LumberjackLogDriver,
   LumberjackLogDriverLog,
@@ -109,7 +110,13 @@ describe(LumberjackHttpDriver.name, () => {
     [LumberjackLevel.Info, (driver) => driver.logInfo],
     [LumberjackLevel.Trace, (driver) => driver.logTrace],
     [LumberjackLevel.Warning, (driver) => driver.logWarning],
-  ] as ReadonlyArray<[LumberjackLogLevel, (driver: LumberjackLogDriver<HttpDriverPayload>) => (driverLog: LumberjackLogDriverLog<HttpDriverPayload>) => void]>)(
+    ['critical', (driver) => driver.logCritical],
+    ['debug', (driver) => driver.logDebug],
+    ['error', (driver) => driver.logError],
+    ['info', (driver) => driver.logInfo],
+    ['trace', (driver) => driver.logTrace],
+    ['warn', (driver) => driver.logWarning],
+  ] as ReadonlyArray<[LumberjackLogLevel | LogLevel, (driver: LumberjackLogDriver<HttpDriverPayload>) => (driverLog: LumberjackLogDriverLog<HttpDriverPayload>) => void]>)(
     'logs to a web API using the %s log level',
     (logLevel, logMethod) => {
       it('sends the driver log to the configured URL', () => {
@@ -123,12 +130,7 @@ describe(LumberjackHttpDriver.name, () => {
   );
 
   it('retries after two failures and then succeeds', () => {
-    const expectedDriverLog = createCriticalDriverLog<HttpDriverPayload>(
-      LumberjackLevel.Critical,
-      '',
-      'Test',
-      analyticsPayload
-    );
+    const expectedDriverLog = createCriticalDriverLog<HttpDriverPayload>('critical', '', 'Test', analyticsPayload);
 
     httpDriver.logCritical(expectedDriverLog);
 
@@ -140,12 +142,7 @@ describe(LumberjackHttpDriver.name, () => {
   });
 
   it('retries the specified number of times after failures and then stops retrying', () => {
-    const expectedDriverLog = createCriticalDriverLog<HttpDriverPayload>(
-      LumberjackLevel.Critical,
-      '',
-      'Test',
-      analyticsPayload
-    );
+    const expectedDriverLog = createCriticalDriverLog<HttpDriverPayload>('critical', '', 'Test', analyticsPayload);
 
     httpDriver.logCritical(expectedDriverLog);
     const { retryOptions } = options;

--- a/packages/ngworker/lumberjack/src/index.ts
+++ b/packages/ngworker/lumberjack/src/index.ts
@@ -26,10 +26,10 @@ export { LumberjackLogFactory } from './lib/logging/lumberjack-log-factory';
 export { LumberjackLogBuilder } from './lib/logging/lumberjack-log.builder';
 
 // Logs
-export { LumberjackConfigLevels } from './lib/logs/lumberjack-config-levels';
-export { LumberjackLevel } from './lib/logs/lumberjack-level';
+export { LumberjackConfigLevels, ConfigLevels } from './lib/logs/lumberjack-config-levels';
+export { LumberjackLevel, Level } from './lib/logs/lumberjack-level';
 export { LumberjackLog } from './lib/logs/lumberjack.log';
-export { LumberjackLogLevel } from './lib/logs/lumberjack-log-level';
+export { LumberjackLogLevel, LogLevel } from './lib/logs/lumberjack-log-level';
 export { LumberjackLogPayload } from './lib/logs/lumberjack-log-payload';
 
 // Time

--- a/packages/ngworker/lumberjack/src/lib/configuration/lumberjack-log-driver.config.ts
+++ b/packages/ngworker/lumberjack/src/lib/configuration/lumberjack-log-driver.config.ts
@@ -1,4 +1,4 @@
-import { LumberjackConfigLevels } from '../logs/lumberjack-config-levels';
+import { ConfigLevels, LumberjackConfigLevels } from '../logs/lumberjack-config-levels';
 
 /**
  * Settings for a log driver.
@@ -9,7 +9,7 @@ export interface LumberjackLogDriverConfig {
    *
    * `[LumberjackLevel.Verbose]` indicates that all log levels are allowed.
    */
-  readonly levels: LumberjackConfigLevels;
+  readonly levels: LumberjackConfigLevels | ConfigLevels;
 
   /**
    * Driver Identifier, necessary for driver filtering.

--- a/packages/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.spec.ts
+++ b/packages/ngworker/lumberjack/src/lib/formatting/lumberjack-format-log.spec.ts
@@ -4,7 +4,7 @@ import { LumberjackModule } from '../configuration/lumberjack.module';
 import { LumberjackLogFactory } from '../logging/lumberjack-log-factory';
 import { LumberjackLogBuilder } from '../logging/lumberjack-log.builder';
 import { LumberjackLevel } from '../logs/lumberjack-level';
-import { LumberjackLogLevel } from '../logs/lumberjack-log-level';
+import { LogLevel, LumberjackLogLevel } from '../logs/lumberjack-log-level';
 import { LumberjackLog } from '../logs/lumberjack.log';
 import { LumberjackTimeService } from '../time/lumberjack-time.service';
 
@@ -38,13 +38,19 @@ describe(lumberjackFormatLog.name, () => {
   let logFactory: LumberjackLogFactory;
 
   describe('Log level', () => {
-    const logLevels: LumberjackLogLevel[] = [
+    const logLevels: (LumberjackLogLevel | LogLevel)[] = [
       LumberjackLevel.Critical,
       LumberjackLevel.Debug,
       LumberjackLevel.Error,
       LumberjackLevel.Info,
       LumberjackLevel.Trace,
       LumberjackLevel.Warning,
+      'critical',
+      'debug',
+      'error',
+      'info',
+      'trace',
+      'warn',
     ];
 
     logLevels.forEach((expectedLevel) => {

--- a/packages/ngworker/lumberjack/src/lib/log-drivers/lumberjack-log-driver-logger.ts
+++ b/packages/ngworker/lumberjack/src/lib/log-drivers/lumberjack-log-driver-logger.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 
-import { LumberjackLevel } from '../logs/lumberjack-level';
 import { LumberjackLogLevel } from '../logs/lumberjack-log-level';
 import { LumberjackLogPayload } from '../logs/lumberjack-log-payload';
 
@@ -23,12 +22,12 @@ export class LumberjackLogDriverLogger<TPayload extends LumberjackLogPayload | v
    * A record of logging strategies for each log level.
    */
   readonly #loggingStrategies: Readonly<Record<LumberjackLogLevel, LumberjackLogDriverLoggingStrategy<TPayload>>> = {
-    [LumberjackLevel.Critical]: criticalLogDriverLoggingStrategy,
-    [LumberjackLevel.Debug]: debugLogDriverLoggingStrategy,
-    [LumberjackLevel.Error]: errorLogDriverLoggingStrategy,
-    [LumberjackLevel.Info]: infoLogDriverLoggingStrategy,
-    [LumberjackLevel.Trace]: traceLogDriverLoggingStrategy,
-    [LumberjackLevel.Warning]: warningLogDriverLoggingStrategy,
+    ['critical']: criticalLogDriverLoggingStrategy,
+    ['debug']: debugLogDriverLoggingStrategy,
+    ['error']: errorLogDriverLoggingStrategy,
+    ['info']: infoLogDriverLoggingStrategy,
+    ['trace']: traceLogDriverLoggingStrategy,
+    ['warn']: warningLogDriverLoggingStrategy,
   };
 
   /**

--- a/packages/ngworker/lumberjack/src/lib/logging/lumberjack-log.builder.spec.ts
+++ b/packages/ngworker/lumberjack/src/lib/logging/lumberjack-log.builder.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { FakeTimeService } from '@internal/test-util';
 
 import { LumberjackLevel } from '../logs/lumberjack-level';
-import { LumberjackLogLevel } from '../logs/lumberjack-log-level';
+import { LogLevel, LumberjackLogLevel } from '../logs/lumberjack-log-level';
 import { LumberjackLogPayload } from '../logs/lumberjack-log-payload';
 import { LumberjackLog } from '../logs/lumberjack.log';
 import { LumberjackTimeService } from '../time/lumberjack-time.service';
@@ -14,7 +14,12 @@ interface TestPayload extends LumberjackLogPayload {
   testProperty: string;
 }
 
-const lumberjackLogLevels: LumberjackLogLevel[] = [LumberjackLevel.Critical, LumberjackLevel.Error];
+const lumberjackLogLevels: (LumberjackLogLevel | LogLevel)[] = [
+  LumberjackLevel.Critical,
+  LumberjackLevel.Error,
+  'critical',
+  'error',
+];
 
 describe(LumberjackLogBuilder.name, () => {
   const testMessage = 'Test Message';
@@ -48,7 +53,7 @@ describe(LumberjackLogBuilder.name, () => {
   });
 
   it('creates a log with the specified scope', () => {
-    const level = LumberjackLevel.Critical;
+    const level = 'critical';
     const scope = 'Test Scope';
     const actualLog = new LumberjackLogBuilder(fakeTime, level, testMessage).withScope(scope).build();
 
@@ -64,7 +69,7 @@ describe(LumberjackLogBuilder.name, () => {
   });
 
   describe('using Payload', () => {
-    const level = LumberjackLevel.Critical;
+    const level = 'critical';
     const scope = 'Test Scope';
     const payload: TestPayload = {
       testProperty: 'TEST_PROPERTY',

--- a/packages/ngworker/lumberjack/src/lib/logging/lumberjack-log.builder.ts
+++ b/packages/ngworker/lumberjack/src/lib/logging/lumberjack-log.builder.ts
@@ -1,4 +1,4 @@
-import { LumberjackLogLevel } from '../logs/lumberjack-log-level';
+import { LogLevel, LumberjackLogLevel } from '../logs/lumberjack-log-level';
 import { LumberjackLogPayload } from '../logs/lumberjack-log-payload';
 import { LumberjackLog } from '../logs/lumberjack.log';
 import { LumberjackTimeService } from '../time/lumberjack-time.service';
@@ -18,7 +18,7 @@ export class LumberjackLogBuilder<TPayload extends LumberjackLogPayload | void =
   #payload?: TPayload;
   #scope?: string;
   readonly #time: LumberjackTimeService;
-  readonly #level: LumberjackLogLevel;
+  readonly #level: LumberjackLogLevel | LogLevel;
   readonly #message: string;
 
   /**
@@ -28,7 +28,7 @@ export class LumberjackLogBuilder<TPayload extends LumberjackLogPayload | void =
    * @param level The log level.
    * @param message The log message.
    */
-  constructor(time: LumberjackTimeService, level: LumberjackLogLevel, message: string) {
+  constructor(time: LumberjackTimeService, level: LumberjackLogLevel | LogLevel, message: string) {
     this.#time = time;
     this.#level = level;
     this.#message = message;

--- a/packages/ngworker/lumberjack/src/lib/logging/lumberjack-logger.builder.spec.ts
+++ b/packages/ngworker/lumberjack/src/lib/logging/lumberjack-logger.builder.spec.ts
@@ -3,8 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { FakeTimeService } from '@internal/test-util';
 
 import { LumberjackModule } from '../configuration/lumberjack.module';
-import { LumberjackLevel } from '../logs/lumberjack-level';
-import { LumberjackLogLevel } from '../logs/lumberjack-log-level';
+import { LogLevel, LumberjackLogLevel } from '../logs/lumberjack-log-level';
 import { LumberjackLogPayload } from '../logs/lumberjack-log-payload';
 import { LumberjackLog } from '../logs/lumberjack.log';
 import { LumberjackTimeService } from '../time/lumberjack-time.service';
@@ -17,7 +16,7 @@ interface TestPayload extends LumberjackLogPayload {
   testProperty: string;
 }
 
-const lumberjackLogLevels: LumberjackLogLevel[] = [LumberjackLevel.Critical, LumberjackLevel.Error];
+const lumberjackLogLevels: (LumberjackLogLevel | LogLevel)[] = ['critical', 'error'];
 
 describe(LumberjackLoggerBuilder.name, () => {
   const testMessage = 'Test Message';
@@ -53,7 +52,7 @@ describe(LumberjackLoggerBuilder.name, () => {
   });
 
   it('logs the specified scope', () => {
-    const level = LumberjackLevel.Critical;
+    const level = 'critical';
     const scope = 'Test Scope';
     const builder = new LumberjackLoggerBuilder(lumberjackService, fakeTime, level, testMessage);
     const logFunction = builder.withScope(scope).build();
@@ -66,7 +65,7 @@ describe(LumberjackLoggerBuilder.name, () => {
   });
 
   describe('LumberjackLogPayload', () => {
-    const level = LumberjackLevel.Critical;
+    const level = 'critical';
     const scope = 'Test Scope';
     const payload: TestPayload = {
       testProperty: 'TEST_PROPERTY',

--- a/packages/ngworker/lumberjack/src/lib/logging/lumberjack-logger.builder.ts
+++ b/packages/ngworker/lumberjack/src/lib/logging/lumberjack-logger.builder.ts
@@ -1,4 +1,4 @@
-import { LumberjackLogLevel } from '../logs/lumberjack-log-level';
+import { LogLevel, LumberjackLogLevel } from '../logs/lumberjack-log-level';
 import { LumberjackLogPayload } from '../logs/lumberjack-log-payload';
 import { LumberjackTimeService } from '../time/lumberjack-time.service';
 
@@ -9,13 +9,13 @@ export class LumberjackLoggerBuilder<TPayload extends LumberjackLogPayload | voi
   #payload?: TPayload;
   readonly #lumberjack: LumberjackService<TPayload>;
   readonly #time: LumberjackTimeService;
-  readonly #level: LumberjackLogLevel;
+  readonly #level: LumberjackLogLevel | LogLevel;
   readonly #message: string;
 
   constructor(
     lumberjack: LumberjackService<TPayload>,
     time: LumberjackTimeService,
-    level: LumberjackLogLevel,
+    level: LumberjackLogLevel | LogLevel,
     message: string
   ) {
     this.#lumberjack = lumberjack;

--- a/packages/ngworker/lumberjack/src/lib/logging/lumberjack-logger.service.ts
+++ b/packages/ngworker/lumberjack/src/lib/logging/lumberjack-logger.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 
 import { LumberjackLevel } from '../logs/lumberjack-level';
-import { LumberjackLogLevel } from '../logs/lumberjack-log-level';
+import { LogLevel, LumberjackLogLevel } from '../logs/lumberjack-log-level';
 import { LumberjackLogPayload } from '../logs/lumberjack-log-payload';
 import { LumberjackTimeService } from '../time/lumberjack-time.service';
 
@@ -25,35 +25,35 @@ export abstract class LumberjackLogger<TPayload extends LumberjackLogPayload | v
    * Create a logger builder for a critical log with the specified message.
    */
   protected createCriticalLogger(message: string): LumberjackLoggerBuilder<TPayload> {
-    return this.createLoggerBuilder(LumberjackLevel.Critical, message);
+    return this.createLoggerBuilder('critical', message);
   }
 
   /**
    * Create a logger builder for a debug log with the specified message.
    */
   protected createDebugLogger(message: string): LumberjackLoggerBuilder<TPayload> {
-    return this.createLoggerBuilder(LumberjackLevel.Debug, message);
+    return this.createLoggerBuilder('debug', message);
   }
 
   /**
    * Create a logger builder for an error log with the specified message.
    */
   protected createErrorLogger(message: string): LumberjackLoggerBuilder<TPayload> {
-    return this.createLoggerBuilder(LumberjackLevel.Error, message);
+    return this.createLoggerBuilder('error', message);
   }
 
   /**
    * Create a logger builder for an info log with the specified message.
    */
   protected createInfoLogger(message: string): LumberjackLoggerBuilder<TPayload> {
-    return this.createLoggerBuilder(LumberjackLevel.Info, message);
+    return this.createLoggerBuilder('info', message);
   }
 
   /**
    * Create a logger builder for a trace log with the specified message.
    */
   protected createTraceLogger(message: string): LumberjackLoggerBuilder<TPayload> {
-    return this.createLoggerBuilder(LumberjackLevel.Trace, message);
+    return this.createLoggerBuilder('trace', message);
   }
 
   /**
@@ -66,7 +66,10 @@ export abstract class LumberjackLogger<TPayload extends LumberjackLogPayload | v
   /**
    * Create a logger builder for a log with the specified log level and message.
    */
-  protected createLoggerBuilder(level: LumberjackLogLevel, message: string): LumberjackLoggerBuilder<TPayload> {
+  protected createLoggerBuilder(
+    level: LumberjackLogLevel | LogLevel,
+    message: string
+  ): LumberjackLoggerBuilder<TPayload> {
     return new LumberjackLoggerBuilder<TPayload>(this.lumberjack, this.time, level, message);
   }
 }

--- a/packages/ngworker/lumberjack/src/lib/logging/lumberjack.service.ts
+++ b/packages/ngworker/lumberjack/src/lib/logging/lumberjack.service.ts
@@ -6,8 +6,7 @@ import { LumberjackLogDriver } from '../log-drivers/lumberjack-log-driver';
 import { LumberjackLogDriverError } from '../log-drivers/lumberjack-log-driver-error';
 import { LumberjackLogDriverLogger } from '../log-drivers/lumberjack-log-driver-logger';
 import { lumberjackLogDriverToken } from '../log-drivers/lumberjack-log-driver.token';
-import { LumberjackLevel } from '../logs/lumberjack-level';
-import { LumberjackLogLevel } from '../logs/lumberjack-log-level';
+import { LogLevel, LumberjackLogLevel } from '../logs/lumberjack-log-level';
 import { LumberjackLogPayload } from '../logs/lumberjack-log-payload';
 import { LumberjackLog } from '../logs/lumberjack.log';
 import { LumberjackTimeService } from '../time/lumberjack-time.service';
@@ -64,7 +63,7 @@ export class LumberjackService<TPayload extends LumberjackLogPayload | void = vo
   logCritical(message: string, payload?: TPayload, scope?: string): void {
     this.log({
       createdAt: this.#time.getUnixEpochTicks(),
-      level: LumberjackLevel.Critical,
+      level: 'critical',
       message,
       payload,
       scope,
@@ -82,7 +81,7 @@ export class LumberjackService<TPayload extends LumberjackLogPayload | void = vo
   logError(message: string, payload?: TPayload, scope?: string): void {
     this.log({
       createdAt: this.#time.getUnixEpochTicks(),
-      level: LumberjackLevel.Error,
+      level: 'error',
       message,
       payload,
       scope,
@@ -100,7 +99,7 @@ export class LumberjackService<TPayload extends LumberjackLogPayload | void = vo
   logWarning(message: string, payload?: TPayload, scope?: string): void {
     this.log({
       createdAt: this.#time.getUnixEpochTicks(),
-      level: LumberjackLevel.Warning,
+      level: 'warn',
       message,
       payload,
       scope,
@@ -118,7 +117,7 @@ export class LumberjackService<TPayload extends LumberjackLogPayload | void = vo
   logInfo(message: string, payload?: TPayload, scope?: string): void {
     this.log({
       createdAt: this.#time.getUnixEpochTicks(),
-      level: LumberjackLevel.Info,
+      level: 'info',
       message,
       payload,
       scope,
@@ -136,7 +135,7 @@ export class LumberjackService<TPayload extends LumberjackLogPayload | void = vo
   logDebug(message: string, payload?: TPayload, scope?: string): void {
     this.log({
       createdAt: this.#time.getUnixEpochTicks(),
-      level: LumberjackLevel.Debug,
+      level: 'debug',
       message,
       payload,
       scope,
@@ -154,7 +153,7 @@ export class LumberjackService<TPayload extends LumberjackLogPayload | void = vo
   logTrace(message: string, payload?: TPayload, scope?: string): void {
     this.log({
       createdAt: this.#time.getUnixEpochTicks(),
-      level: LumberjackLevel.Trace,
+      level: 'trace',
       message,
       payload,
       scope,
@@ -168,9 +167,9 @@ export class LumberjackService<TPayload extends LumberjackLogPayload | void = vo
    * @param driver The configured log driver.
    * @param logLevel The log's log level.
    */
-  #canDriveLog(driver: LumberjackLogDriver<TPayload>, logLevel: LumberjackLogLevel): boolean {
-    const hasVerboseLogging = driver.config.levels.length === 1 && driver.config.levels[0] === LumberjackLevel.Verbose;
-    const acceptsLogLevel = (driver.config.levels as LumberjackLogLevel[]).includes(logLevel);
+  #canDriveLog(driver: LumberjackLogDriver<TPayload>, logLevel: LumberjackLogLevel | LogLevel): boolean {
+    const hasVerboseLogging = driver.config.levels.length === 1 && driver.config.levels[0] === 'verbose';
+    const acceptsLogLevel = (driver.config.levels as (LumberjackLogLevel | LogLevel)[]).includes(logLevel);
 
     return hasVerboseLogging || acceptsLogLevel;
   }
@@ -183,7 +182,7 @@ export class LumberjackService<TPayload extends LumberjackLogPayload | void = vo
   #createDriverErrorLog(driverError: LumberjackLogDriverError<TPayload>): LumberjackLog<TPayload> {
     return {
       createdAt: this.#time.getUnixEpochTicks(),
-      level: LumberjackLevel.Error,
+      level: 'error',
       message: formatLogDriverError(driverError),
       scope: 'LumberjackLogDriverError',
     };

--- a/packages/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.ts
+++ b/packages/ngworker/lumberjack/src/lib/logging/scoped-lumberjack-logger.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 
-import { LumberjackLogLevel } from '../logs/lumberjack-log-level';
+import { LogLevel, LumberjackLogLevel } from '../logs/lumberjack-log-level';
 import { LumberjackLogPayload } from '../logs/lumberjack-log-payload';
 import { LumberjackTimeService } from '../time/lumberjack-time.service';
 
@@ -31,7 +31,7 @@ export abstract class ScopedLumberjackLogger<
    * specified log level and message.
    */
   protected override createLoggerBuilder(
-    level: LumberjackLogLevel,
+    level: LumberjackLogLevel | LogLevel,
     message: string
   ): LumberjackLoggerBuilder<TPayload> {
     return new LumberjackLoggerBuilder<TPayload>(this.lumberjack, this.time, level, message).withScope(this.scope);

--- a/packages/ngworker/lumberjack/src/lib/logs/lumberjack-config-levels.ts
+++ b/packages/ngworker/lumberjack/src/lib/logs/lumberjack-config-levels.ts
@@ -1,8 +1,23 @@
-import { LumberjackLevel } from './lumberjack-level';
-import { LumberjackLogLevel } from './lumberjack-log-level';
+import { Level, LumberjackLevel } from './lumberjack-level';
+import { LogLevel, LumberjackLogLevel } from './lumberjack-log-level';
 
 /**
  * A set of Levels used to configure a log driver. Lumberjack filters logs
  * passed to the log driver based on its configured log levels.
+ *
+ * @deprecated use `ConfigLevels` instead. Enums will be removed in Lumberjack 19 in favor of string literal types.
  */
 export type LumberjackConfigLevels = LumberjackLogLevel[] | [LumberjackLevel.Verbose];
+
+/**
+ * A set of Levels used to configure a log driver. Lumberjack filters logs
+ * passed to the log driver based on its configured log levels.
+ *
+ * We recommend aliasing `ConfigLevels` to `LumberjackConfigLevels`. This will be the final name after removing enum based levels.
+ *
+ * @example
+ * ```typescript
+ * import { ConfigLevels as LumberjackConfigLevels } from '@ngworker/lumberjack';
+ * ```
+ */
+export type ConfigLevels = LogLevel[] | [Extract<Level, 'verbose'>];

--- a/packages/ngworker/lumberjack/src/lib/logs/lumberjack-level.ts
+++ b/packages/ngworker/lumberjack/src/lib/logs/lumberjack-level.ts
@@ -1,5 +1,8 @@
 /**
- * Level used to configure log drivers or add a log level to a log.
+ * All supported levels supported by Lumberjack. Used to specify the severity of a log and to configure Lumberjack and the log drivers.
+ *
+ * @deprecated use `Level` instead. Enums will be removed in Lumberjack 19 in favor of string literal types.
+ *
  */
 export enum LumberjackLevel {
   Critical = 'critical',
@@ -10,3 +13,15 @@ export enum LumberjackLevel {
   Verbose = 'verbose',
   Warning = 'warn',
 }
+
+/**
+ * All supported levels supported by Lumberjack. Used to specify the severity of a log and to configure Lumberjack and the log drivers.
+ *
+ * We recommend aliasing `Level` to `LumberjackLevel`. This will be the final name after removing enum based levels.
+ *
+ * @example
+ * ```typescript
+ * import { Level as LumberjackLevel } from '@ngworker/lumberjack';
+ * ```
+ */
+export type Level = 'critical' | 'debug' | 'error' | 'info' | 'trace' | 'verbose' | 'warn';

--- a/packages/ngworker/lumberjack/src/lib/logs/lumberjack-log-level.ts
+++ b/packages/ngworker/lumberjack/src/lib/logs/lumberjack-log-level.ts
@@ -1,6 +1,20 @@
-import { LumberjackLevel } from './lumberjack-level';
+import { Level, LumberjackLevel } from './lumberjack-level';
 
 /**
  * Level used to represent severity of a log.
+ *
+ * @deprecated use `LogLevel` instead. Enums will be removed in Lumberjack 19 in favor of string literal types.
  */
 export type LumberjackLogLevel = Exclude<LumberjackLevel, LumberjackLevel.Verbose>;
+
+/**
+ * Level used to represent severity of a log.
+ *
+ * We recommend aliasing `LogLevel` to `LumberjackLogLevel`. This will be the final name after removing enum based levels.
+ *
+ * @example
+ * ```typescript
+ * import { LogLevel as LumberjackLogLevel } from '@ngworker/lumberjack';
+ * ```
+ */
+export type LogLevel = Exclude<Level, 'verbose'>;

--- a/packages/ngworker/lumberjack/src/lib/logs/lumberjack.log.ts
+++ b/packages/ngworker/lumberjack/src/lib/logs/lumberjack.log.ts
@@ -1,4 +1,4 @@
-import { LumberjackLogLevel } from './lumberjack-log-level';
+import { LogLevel, LumberjackLogLevel } from './lumberjack-log-level';
 import { LumberjackLogPayload } from './lumberjack-log-payload';
 
 /**
@@ -12,7 +12,7 @@ export interface LumberjackLog<TPayload extends LumberjackLogPayload | void = vo
   /**
    * Level of severity.
    */
-  readonly level: LumberjackLogLevel;
+  readonly level: LumberjackLogLevel | LogLevel;
 
   /**
    * Log message, for example describing an event that happened.

--- a/packages/ngworker/lumberjack/src/logs-api.spec.ts
+++ b/packages/ngworker/lumberjack/src/logs-api.spec.ts
@@ -1,6 +1,9 @@
 import { isObject } from '@internal/test-util';
 
 import {
+  ConfigLevels,
+  Level,
+  LogLevel,
   LumberjackConfigLevels,
   LumberjackLevel,
   LumberjackLog,
@@ -30,8 +33,26 @@ describe('Logs API', () => {
       expect(value).toBeDefined();
     });
 
+    it('exposes ConfigLevels', () => {
+      const value: ConfigLevels = [];
+
+      expect(value).toBeDefined();
+    });
+
     it('exposes LumberjackLogLevel', () => {
       const value: LumberjackLogLevel | undefined = undefined;
+
+      expect(value).toBeUndefined();
+    });
+
+    it('exposes LogLevel', () => {
+      const value: LogLevel | undefined = undefined;
+
+      expect(value).toBeUndefined();
+    });
+
+    it('exposes Level', () => {
+      const value: Level | undefined = undefined;
 
       expect(value).toBeUndefined();
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Our log levels are represented using TypeScript enums. 

Fixes #192 

## What is the new behavior?

We added support for literal unions for our log levels and deprecated the enums.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

BREAKING CHANGES: enums levels are deprecated and will be removed on version 19.