### PR TITLE
ci: OIDC publish, tag trigger, and release guardrails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,68 @@
 name: Release
 
+# Versioning is local (or a protected maintainer machine):
+#   pnpm exec nx release --skip-publish
+# That bumps package.json, commits, tags vX.Y.Z, pushes, and opens the GitHub Release.
+# This workflow only publishes the tagged commit to npm (and deploys docs).
+
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish, e.g. v22.0.0'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write # required for npm OIDC trusted publishing + provenance
 
 jobs:
-  release:
+  publish:
+    name: Publish to npm
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write # needed for provenance data generation
+    timeout-minutes: 15
+    concurrency:
+      # One run per tag; never cancel a production publish mid-flight.
+      group: publish-${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
+      cancel-in-progress: false
 
     steps:
-      - name: Checkout repository
+      - name: Resolve release tag
+        id: meta
+        # Tag format is `v{version}` (nx.json releaseTag.pattern).
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${{ github.ref_name }}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
+          if [[ "$TAG" =~ ^v(.+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+          else
+            echo "::error::Unrecognized release tag '$TAG' (expected vX.Y.Z)"
+            exit 1
+          fi
+          # Prereleases (any version containing '-') go to the `next` dist-tag.
+          case "$VERSION" in
+            *-*) DIST_TAG="next" ;;
+            *)   DIST_TAG="latest" ;;
+          esac
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "dist_tag=$DIST_TAG"
+          } >> "$GITHUB_OUTPUT"
+          echo "Publishing @ngworker/lumberjack@$VERSION under dist-tag $DIST_TAG"
+        shell: bash
+
+      - name: Checkout release tag
         uses: actions/checkout@v4
         with:
+          ref: refs/tags/${{ steps.meta.outputs.tag }}
           fetch-depth: 0
           filter: tree:0
 
@@ -23,34 +70,102 @@ jobs:
         with:
           version: 10
 
+      # setup-node provides node + npm. No registry-url on purpose: it writes an
+      # .npmrc with //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}, and an
+      # empty/unresolved token there breaks OIDC trusted publishing.
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Upgrade npm for OIDC trusted publishing
+        # npm OIDC trusted publishing needs npm >= 11.5.1; Node 22 ships 10.x.
+        run: npm install -g npm@11
+        shell: bash
+
       - name: Print Environment Info
-        run: npx nx report
+        run: pnpm exec nx report
+        shell: bash
+
+      - name: Assert source manifest matches tag
+        # The release commit (created by `nx release --skip-publish`) is the
+        # tagged commit, so the source package.json must already carry the
+        # tag's version. A mismatch means we're about to publish the wrong bits.
+        run: |
+          MANIFEST_VERSION=$(node -p "require('./packages/ngworker/lumberjack/package.json').version")
+          if [ "$MANIFEST_VERSION" != "${{ steps.meta.outputs.version }}" ]; then
+            echo "::error::packages/ngworker/lumberjack/package.json is at $MANIFEST_VERSION but tag says ${{ steps.meta.outputs.version }}"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Check whether version is already published
+        id: published
+        # npm versions are immutable. If this exact version is already live
+        # (e.g. a re-run after a green publish), skip the remaining steps and
+        # succeed — re-publishing would hard-fail, and there is nothing to do.
+        run: |
+          if npm view "@ngworker/lumberjack@${{ steps.meta.outputs.version }}" version >/dev/null 2>&1; then
+            echo "::notice::@ngworker/lumberjack@${{ steps.meta.outputs.version }} is already on the registry — nothing to publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
         shell: bash
 
       - name: Build
+        if: steps.published.outputs.skip != 'true'
         run: pnpm exec nx build ngworker-lumberjack
         shell: bash
 
-      - name: Publish Package
+      - name: Assert dist manifest matches tag
+        if: steps.published.outputs.skip != 'true'
+        # Publish packs dist/. Guards the historical failure mode where a stale
+        # dist/ at the old version was silently re-tagged instead of published.
+        run: |
+          DIST_VERSION=$(node -p "require('./dist/packages/ngworker/lumberjack/package.json').version")
+          if [ "$DIST_VERSION" != "${{ steps.meta.outputs.version }}" ]; then
+            echo "::error::dist/packages/ngworker/lumberjack is at $DIST_VERSION but tag says ${{ steps.meta.outputs.version }}"
+            exit 1
+          fi
         shell: bash
-        run: pnpm exec nx release publish --projects=ngworker-lumberjack
+
+      - name: Publish package
+        if: steps.published.outputs.skip != 'true'
+        # Tokenless publish via npm OIDC trusted publishing (configure on npmjs
+        # for this workflow file + repo). Direct `npm publish` of the built dist
+        # dir — NOT `nx release publish` — so OIDC engages and provenance is
+        # emitted automatically. Relies on id-token: write.
+        run: |
+          npm publish "dist/packages/ngworker/lumberjack" \
+            --tag "${{ steps.meta.outputs.dist_tag }}" \
+            --access public
+        shell: bash
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          # This is needed for actions/setup-node authentication to work
           npm_config_registry: https://registry.npmjs.org
 
+      - name: Verify package is live
+        if: steps.published.outputs.skip != 'true'
+        run: |
+          PKG="@ngworker/lumberjack"
+          VERSION="${{ steps.meta.outputs.version }}"
+          for attempt in 1 2 3 4 5; do
+            if npm view "$PKG@$VERSION" version >/dev/null 2>&1; then
+              echo "✓ $PKG@$VERSION is live"
+              exit 0
+            fi
+            echo "… $PKG@$VERSION not visible yet (attempt $attempt/5), retrying"
+            sleep 5
+          done
+          echo "::error::$PKG@$VERSION not found on the registry after publish"
+          exit 1
+        shell: bash
+
   deploy-docs:
-    name: '[Merge] Deploy docs to GitHub Pages'
-    needs: release
+    name: Deploy docs to GitHub Pages
+    needs: publish
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,10 +179,11 @@ jobs:
       - name: Check out the source code
         uses: actions/checkout@v4
         with:
+          # Publish checked out the tag; docs should match the same release.
+          ref: ${{ github.event_name == 'push' && github.ref || format('refs/tags/{0}', inputs.tag) }}
           fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
-      # Uses the cache generated in the distributed step
       - name: Build docs
         run: pnpm exec nx build docs-lumberjack-docs-app
       - name: Set up GitHub Pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,55 @@ pnpm exec start
 pnpm exec build
 ```
 
+## Releasing
+
+Versioning and publishing are separate steps.
+
+### 1. Version (maintainer machine)
+
+```bash
+pnpm exec nx release --skip-publish
+```
+
+This uses conventional commits to bump `@ngworker/lumberjack`, updates the package
+manifest, commits, creates tag `v{version}`, pushes, and opens a GitHub Release.
+Do **not** publish from this step — CI owns the registry.
+
+Dry-run first if unsure:
+
+```bash
+pnpm exec nx release --skip-publish --dry-run
+```
+
+### 2. Publish (CI)
+
+Pushing tag `v*` triggers [`.github/workflows/release.yml`](.github/workflows/release.yml):
+
+1. Check out the tag
+2. Assert source `package.json` version matches the tag
+3. Skip if that version is already on npm (idempotent re-runs)
+4. Build, assert dist version matches the tag
+5. `npm publish dist/packages/ngworker/lumberjack` via **OIDC trusted publishing**
+   (no `NPM_TOKEN`; provenance is automatic)
+6. Verify the version is live, then deploy docs
+
+Prerelease versions (containing `-`) publish under the `next` dist-tag; stable
+versions use `latest`.
+
+### npm trusted publisher setup (one-time)
+
+On [npmjs.com](https://www.npmjs.com/package/@ngworker/lumberjack) → package
+settings → **Trusted Publisher**, add:
+
+| Field | Value |
+| --- | --- |
+| Repository owner | `ngworker` |
+| Repository name | `lumberjack` |
+| Workflow filename | `release.yml` |
+| Environment | _(leave empty)_ |
+
+OIDC requires npm ≥ 11.5.1 on the runner (the workflow upgrades npm for this).
+
 ## <a name="rules"></a> Coding Rules
 
 To ensure consistency throughout the source code, keep these rules in mind as you are working:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,15 @@ Dry-run first if unsure:
 pnpm exec nx release --skip-publish --dry-run
 ```
 
+Always confirm the resolved version before running without `--dry-run`. Squash-merge
+PR bodies can confuse the conventional-commits parser (e.g. a `feat!:` title may
+still resolve as a patch). Force the version when needed:
+
+```bash
+pnpm exec nx release 22.0.0 --skip-publish --dry-run
+pnpm exec nx release 22.0.0 --skip-publish
+```
+
 ### 2. Publish (CI)
 
 Pushing tag `v*` triggers [`.github/workflows/release.yml`](.github/workflows/release.yml):
@@ -69,12 +78,12 @@ versions use `latest`.
 On [npmjs.com](https://www.npmjs.com/package/@ngworker/lumberjack) → package
 settings → **Trusted Publisher**, add:
 
-| Field | Value |
-| --- | --- |
-| Repository owner | `ngworker` |
-| Repository name | `lumberjack` |
-| Workflow filename | `release.yml` |
-| Environment | _(leave empty)_ |
+| Field             | Value           |
+| ----------------- | --------------- |
+| Repository owner  | `ngworker`      |
+| Repository name   | `lumberjack`    |
+| Workflow filename | `release.yml`   |
+| Environment       | _(leave empty)_ |
 
 OIDC requires npm ≥ 11.5.1 on the runner (the workflow upgrades npm for this).
 

--- a/e2e/docs/lumberjack-docs-app-e2e/cypress.config.ts
+++ b/e2e/docs/lumberjack-docs-app-e2e/cypress.config.ts
@@ -5,9 +5,11 @@ export default defineConfig({
   e2e: {
     ...nxE2EPreset(__filename, {
       cypressDir: 'src',
+      // Docusaurus has no serve:development/production configs — use `start` (dev
+      // server, no pre-build) so e2e does not race the static `serve` target that
+      // requires packages/docs/lumberjack-docs-app/build.
       webServerCommands: {
-        default: 'nx run docs-lumberjack-docs-app:serve:development',
-        production: 'nx run docs-lumberjack-docs-app:serve:production',
+        default: 'nx run docs-lumberjack-docs-app:start',
       },
       ciWebServerCommand: 'nx run docs-lumberjack-docs-app:start',
     }),

--- a/e2e/docs/lumberjack-docs-app-e2e/project.json
+++ b/e2e/docs/lumberjack-docs-app-e2e/project.json
@@ -5,9 +5,5 @@
   "projectType": "application",
   "tags": ["scope:internal", "type:e2e"],
   "implicitDependencies": ["docs-lumberjack-docs-app"],
-  "targets": {
-    "e2e": {
-      "dependsOn": ["start"]
-    }
-  }
+  "targets": {}
 }

--- a/nx.json
+++ b/nx.json
@@ -177,7 +177,9 @@
       "conventionalCommits": true,
       "git": {
         "commit": true,
-        "commitArgs": "--no-verify"
+        "commitArgs": "--no-verify",
+        "tag": true,
+        "push": true
       }
     },
     "changelog": {
@@ -188,7 +190,9 @@
       "workspaceChangelog": false,
       "git": {
         "commit": true,
-        "commitArgs": "--no-verify"
+        "commitArgs": "--no-verify",
+        "tag": true,
+        "push": true
       }
     },
     "releaseTag": {

--- a/nx.json
+++ b/nx.json
@@ -172,28 +172,22 @@
   "release": {
     "projects": ["ngworker-lumberjack"],
     "projectsRelationship": "independent",
+    "git": {
+      "commit": true,
+      "commitArgs": "--no-verify",
+      "tag": true,
+      "push": true
+    },
     "version": {
       "preVersionCommand": "pnpm exec nx run-many -t build",
-      "conventionalCommits": true,
-      "git": {
-        "commit": true,
-        "commitArgs": "--no-verify",
-        "tag": true,
-        "push": true
-      }
+      "conventionalCommits": true
     },
     "changelog": {
       "projectChangelogs": {
         "createRelease": "github",
         "file": false
       },
-      "workspaceChangelog": false,
-      "git": {
-        "commit": true,
-        "commitArgs": "--no-verify",
-        "tag": true,
-        "push": true
-      }
+      "workspaceChangelog": false
     },
     "releaseTag": {
       "pattern": "v{version}"


### PR DESCRIPTION
## Summary

Modernize the release pipeline to match current Nx + npm practice (aligned with naxodev/oss, adapted for a single package).

### Changes

1. **OIDC trusted publishing** — drop `NPM_TOKEN` / `registry-url` on `setup-node`; publish with `npm publish dist/...` after upgrading npm to 11. Provenance is automatic via `id-token: write`.
2. **Version / publish separation** — local `nx release --skip-publish` versions, tags `v*`, pushes, and creates the GitHub Release. CI only publishes.
3. **Tag trigger** — `push: tags: ['v*']` (+ `workflow_dispatch` with tag input). No more `on: release` (which raced with `createRelease: github` and failed on v21).
4. **Guardrails**
   - source `package.json` version must match tag
   - skip if version already on npm (idempotent re-runs)
   - dist manifest version must match tag
   - post-publish `npm view` retry loop
   - prereleases → `next` dist-tag; stable → `latest`
5. **nx.json** — `version.git` / `changelog.git` now `tag` + `push` so the version step publishes the tag that kicks CI.
6. **CONTRIBUTING.md** — releasing docs + one-time npm trusted-publisher setup table.

### One-time manual step (before first OIDC publish)

On npmjs.com → `@ngworker/lumberjack` → **Trusted Publisher**:

| Field | Value |
| --- | --- |
| Owner | `ngworker` |
| Repo | `lumberjack` |
| Workflow | `release.yml` |
| Environment | _(empty)_ |

After that is configured, `NPM_TOKEN` can be removed from repo secrets.

### Release flow for v22

```bash
pnpm exec nx release --skip-publish --dry-run   # confirm 22.0.0 from feat!
pnpm exec nx release --skip-publish             # version, tag, push, GH release
# CI picks up v22.0.0 → publish + docs
```

## Test plan

- [ ] Workflow YAML parses
- [ ] `nx release --printConfig` resolves git push/tag
- [ ] After merge: configure npm trusted publisher
- [ ] Dry-run version for v22 before real cut