### PR TITLE
chore(release): disable conventional-commit scope matching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,18 +43,18 @@ This uses conventional commits to bump `@ngworker/lumberjack`, updates the packa
 manifest, commits, creates tag `v{version}`, pushes, and opens a GitHub Release.
 Do **not** publish from this step — CI owns the registry.
 
-Dry-run first if unsure:
+Dry-run first and confirm the resolved version before running without `--dry-run`:
 
 ```bash
 pnpm exec nx release --skip-publish --dry-run
 ```
 
-Always confirm the resolved version before running without `--dry-run`. Squash-merge
-PR bodies can confuse the conventional-commits parser (e.g. a `feat!:` title may
-still resolve as a patch). Force the version when needed:
+`release.conventionalCommits.useCommitScope` is `false` (single publishable package),
+so conventional commit types/`!` apply from file-affected history regardless of scope
+(e.g. `feat(core)!: …` still majors). Force an exact version only when you need to
+override the resolver:
 
 ```bash
-pnpm exec nx release 22.0.0 --skip-publish --dry-run
 pnpm exec nx release 22.0.0 --skip-publish
 ```
 

--- a/nx.json
+++ b/nx.json
@@ -182,6 +182,9 @@
       "preVersionCommand": "pnpm exec nx run-many -t build",
       "conventionalCommits": true
     },
+    "conventionalCommits": {
+      "useCommitScope": false
+    },
     "changelog": {
       "projectChangelogs": {
         "createRelease": "github",


### PR DESCRIPTION
## Summary

Set `release.conventionalCommits.useCommitScope: false`.

With the default (`true`), a commit like `feat(core)!: …` only major-bumps when the scope matches an Nx project name. Scope `core` does not match `ngworker-lumberjack`, so the breaking change was demoted to an indirect **patch**. We only publish one package, so scope matching adds no value.

Also trims the outdated workaround note in CONTRIBUTING.

## Test plan

- [x] `nx release --printConfig` shows `useCommitScope: false`