### PR TITLE
ci: deploy docs from main after tag publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,30 +168,14 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     permissions:
+      actions: write # workflow_dispatch of release-docs.yml
       contents: read
-      actions: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Check out the source code
-        uses: actions/checkout@v4
-        with:
-          # Publish checked out the tag; docs should match the same release.
-          ref: ${{ github.event_name == 'push' && github.ref || format('refs/tags/{0}', inputs.tag) }}
-          fetch-depth: 0
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Build docs
-        run: pnpm exec nx build docs-lumberjack-docs-app
-      - name: Set up GitHub Pages
-        uses: actions/configure-pages@v4
-      - name: Upload docs to GitHub Pages
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist/packages/docs/lumberjack-docs-app/
-      - name: Deploy docs to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      # The github-pages environment only allows deploys from `main` (branch
+      # policy). This workflow runs on tag refs (v*), so deploying Pages here
+      # is rejected. Hand off to Release Docs on main instead — the release
+      # commit is already on main when the tag is pushed.
+      - name: Trigger docs deploy on main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release-docs.yml --repo "${{ github.repository }}" --ref main


### PR DESCRIPTION
## Summary

v22.0.0 npm publish succeeded; docs deploy failed immediately with:

> Tag \"v22.0.0\" is not allowed to deploy to github-pages due to environment protection rules.

The `github-pages` environment only allows branches `main` (and a stale docs branch) — not tags. The Release workflow is tag-triggered, so `actions/deploy-pages` is rejected before any step runs.

**Fix:** after a successful publish, `gh workflow run release-docs.yml --ref main` so Pages deploys from an allowed ref. The release commit is already on `main` when the tag is pushed.

Also triggered `Release Docs` manually for the current main (v22 announcement + site).