### PR TITLE
chore: clear sonarcloud code smells failing the quality gate

### DIFF
--- a/e2e/examples/lumberjack-app-e2e/src/e2e/console-driver.cy.ts
+++ b/e2e/examples/lumberjack-app-e2e/src/e2e/console-driver.cy.ts
@@ -1,15 +1,15 @@
 import { VERSION } from '@angular/core';
 
-describe('Console log driver', () => {
-  function visit() {
-    cy.visit('/', {
-      onBeforeLoad(win): void {
-        cy.stub(win.console, 'error').as('consoleError');
-        cy.stub(win.console, 'info').as('consoleInfo');
-      },
-    });
-  }
+function visit() {
+  cy.visit('/', {
+    onBeforeLoad(win): void {
+      cy.stub(win.console, 'error').as('consoleError');
+      cy.stub(win.console, 'info').as('consoleInfo');
+    },
+  });
+}
 
+describe('Console log driver', () => {
   const expectedPayload = {
     angularVersion: VERSION.major,
   };

--- a/packages/internal/test-util/src/lib/spy-driver/spy.driver.ts
+++ b/packages/internal/test-util/src/lib/spy-driver/spy.driver.ts
@@ -13,7 +13,7 @@ import { spyDriverConfigToken } from './spy-driver-config.token';
 export class SpyDriver<TPayload extends LumberjackLogPayload | void = void>
   implements LumberjackLogDriver<TPayload>, jest.Mocked<LumberjackLogDriver>
 {
-  static driverIdentifier = 'SpyDriver';
+  static readonly driverIdentifier = 'SpyDriver';
 
   readonly config = inject(spyDriverConfigToken);
   readonly logCritical = jest.fn();

--- a/packages/ngworker/lumberjack/src/lib/logging/lumberjack-log-factory.spec.ts
+++ b/packages/ngworker/lumberjack/src/lib/logging/lumberjack-log-factory.spec.ts
@@ -123,7 +123,7 @@ describe(LumberjackLogFactory.name, () => {
       expect(new Date(log.createdAt)).toEqual(fakeNow);
     });
 
-    it('timestamps the log with the current date and time', () => {
+    it('timestamps every log with the date and time of its creation', () => {
       const firstLog = logFactory.createWarningLog(testMessage).build();
       const fakeLater = new Date('2021-01-23T23:23:23Z');
       fakeTime.setTime(fakeLater);

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -28,6 +28,16 @@ sonar.coverage.exclusions=tools/scripts/**,packages/internal/**,**/jest.config.t
 # configure the files that should be ignored by duplication detection
 sonar.cpd.exclusions=**/jest.config.ts,**/test.ts,packages/**/main.ts,**/eslint.config.mjs
 
+# Issue exclusions
+# S5914 ("assertion always succeeds") in the `*-api.spec.ts` public API surface
+# tests. Those tests assert the *type* — `const value: SomeExport | undefined`
+# fails to compile if the export is dropped — and the runtime assertion is only
+# there to give the type annotation a test body. Rewriting them to satisfy the
+# rule would delete the thing being tested.
+sonar.issue.ignore.multicriteria=apiSurfaceAssertions
+sonar.issue.ignore.multicriteria.apiSurfaceAssertions.ruleKey=typescript:S5914
+sonar.issue.ignore.multicriteria.apiSurfaceAssertions.resourceKey=**/*-api.spec.ts
+
 # Reports
 # Test coverage reports
 # paths (absolute or relative) to the files with LCOV data

--- a/tools/scripts/configure-sonar-report-paths.mjs
+++ b/tools/scripts/configure-sonar-report-paths.mjs
@@ -49,7 +49,5 @@ function listLintReports() {
   return listFilePaths('reports/**/lint/report.json');
 }
 
-(async () => {
-  await configureCoverageReportPaths();
-  await configureLintReportPaths();
-})();
+await configureCoverageReportPaths();
+await configureLintReportPaths();

--- a/tools/scripts/delete-path-alias.mjs
+++ b/tools/scripts/delete-path-alias.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 function deletePathAlias(alias) {
   const encoding = 'utf8';


### PR DESCRIPTION
## TL;DR

SonarCloud's quality gate has been `ERROR` on `main` while the GitHub check stayed green — 22 code smells and 122 minutes of debt fail the gate's overall-code conditions, and the scan job never waits for the verdict. This PR fixes the 5 actionable smells and excludes the rule behind the other 17, which are deliberate.

**Files to review (6, +24 / −16):**

| File | Why |
|---|---|
| `sonar-project.properties` *(start here)* | Adds the S5914 exclusion — the only change that needs a judgment call. |
| `packages/internal/test-util/src/lib/spy-driver/spy.driver.ts` | S1444: `driverIdentifier` was the lone mutable one across six drivers. |
| `e2e/examples/lumberjack-app-e2e/src/e2e/console-driver.cy.ts` | S7721: `visit` hoisted out of the `describe` callback. |
| `packages/ngworker/lumberjack/src/lib/logging/lumberjack-log-factory.spec.ts` | S8754: two tests shared a title. |
| `tools/scripts/configure-sonar-report-paths.mjs` | S7785: async IIFE → top-level await. |
| `tools/scripts/delete-path-alias.mjs` | S7772: `fs` → `node:fs`. |

## Why

The gate fails on two conditions, both scoped to **overall** code: `code_smells > 0` (actual: 22) and `sqale_index > 0` (actual: 122 min). Every new-code condition passes — 0 new smells, 0 new debt — as do coverage (99.7%), duplication (0.7%), and all six ratings. Nothing recent caused this; the oldest findings date to 2020-12.

Three of the five fixed smells appeared without anyone touching the code. `S7772`, `S7785`, and `S7721` ship in newer analyzer versions and started flagging files that had been stable for years.

## How

17 of the 22 are a single rule, `typescript:S5914` ("assertion always succeeds"), and every one sits in a `*-api.spec.ts` public-API-surface test:

```ts
it('exposes LumberjackConfig', () => {
  const value: LumberjackConfig | undefined = undefined;

  expect(value).toBeUndefined();  // <- S5914
});
```

Sonar is right that the runtime assertion can't fail, and wrong that it matters. The test is the *type annotation* — drop the export and this file stops compiling. Rewriting the assertion to satisfy the rule would delete the thing being tested, so the rule is excluded for that file pattern instead. The remaining 5 are genuine and fixed in place.

## Reviewer notes

- **The exclusion is scoped to one rule and one pattern.** `sonar.issue.ignore.multicriteria` targets `typescript:S5914` on `**/*-api.spec.ts` only. S5914 elsewhere still reports, and the API specs still get every other rule.
- **`readonly` on `SpyDriver` is consistency, not rule-appeasement.** `LumberjackHttpDriver`, `LumberjackConsoleDriver`, `NoopDriver`, `ObjectDriver`, and `ErrorThrowingDriver` all already declare `static readonly driverIdentifier`. `SpyDriver` was the only holdout.
- **The duplicate test titles were not duplicate tests.** The second one asserts that logs built at different times carry different timestamps, so it is renamed to say that rather than deleted.
- **Top-level await is safe here.** `configure-sonar-report-paths.mjs` is ESM and `package.json` pins `engines.node >= 22`.

## Tests

No new tests — every change is a lint-level fix or config. Full verification run locally:

- `nx run-many --target=lint --max-warnings=0` — 7 projects, clean
- `nx run-many --target=test` — 4 projects; `ngworker-lumberjack` alone is 32 suites / 193 tests
- `nx build ngworker-lumberjack` — succeeds
- `nx format:check` — clean
- `configure-sonar-report-paths.mjs` run against a scratch copy of the properties file: exits 0, both placeholders replaced, all three exclusion lines survive the rewrite

Whether the exclusion actually suppresses all 17 findings can only be confirmed by the post-merge analysis on `main` — SonarCloud evaluates only new-code conditions on pull requests, so this PR's own check will not prove it.

## Follow-up

1. Drop `code_smells > 0` and `sqale_index > 0` from **Ngworkers Quality Gate** (id 40275). Overall-code conditions guarantee `main` goes red again on the next analyzer release, and `new_code_smells > 0` already covers what matters. Requires org-admin access in the SonarCloud UI.
2. Add `sonar.qualitygate.wait=true` to the scan step so the GitHub check reflects the gate instead of passing on upload. Worth doing only after (1) lands — otherwise a red gate silently becomes a red `main`.

## Links

- [SonarCloud project dashboard](https://sonarcloud.io/project/overview?id=ngworker_lumberjack)
- [Open issues (22)](https://sonarcloud.io/project/issues?id=ngworker_lumberjack&resolved=false)
