### PR TITLE
ci: fail the sonarcloud job when the quality gate fails

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,6 +12,11 @@ sonar.issues.defaultAssigneeLogin=LayZeeDK@github
 # Scan
 sonar.sourceEncoding=UTF-8
 
+# Block the scan step on the quality gate verdict instead of passing as soon as
+# the report uploads. Without this the GitHub check is green whatever the gate
+# says — it was ERROR on `main` for years before anyone noticed.
+sonar.qualitygate.wait=true
+
 # comma-separated paths to directories containing source files
 sonar.sources=e2e,packages,tools
 # configure the files that should be completely ignored by the analysis


### PR DESCRIPTION
## TL;DR

The SonarCloud job passes the moment the report finishes uploading, so the GitHub check said green while the quality gate sat at `ERROR` on `main` — undetected since 2020. Setting `sonar.qualitygate.wait=true` makes the scanner poll for the verdict and exit non-zero when the gate fails.

Follow-up to #232, which cleared the 22 code smells that had the gate red. Gate on `main` is now `OK` with 0 failing conditions, so this flag lands green.

## Why

`sonarqube-scan-action` uploads the analysis and returns. Computing the gate happens server-side afterwards, and nothing was reading the result — the check reported on the upload, not the verdict. Any gate regression was invisible in CI and only discoverable by opening the SonarCloud dashboard.

| | Before | After |
|---|---|---|
| Job passes when | Report uploads | Gate returns `OK` |
| Gate `ERROR` on `main` | Check stays green | Job fails |
| Gate `ERROR` on a PR | Check stays green | Check blocks merge |

## Reviewer notes

- **Placed in `sonar-project.properties`, not the workflow.** It applies to every analysis — pull request and `main` — rather than only the one CI step, and it lives beside the exclusions it interacts with.
- **PR analyses are judged on new code only.** SonarCloud evaluates just the `new_*` conditions on pull requests, so this blocks a PR that *introduces* smells without holding it responsible for pre-existing ones.
- **This makes the gate load-bearing, which raises the stakes on its conditions.** `Ngworkers Quality Gate` (id 40275) still judges overall code via `code_smells > 0` and `sqale_index > 0`. Those are satisfiable today at 0, but three of the five smells fixed in #232 appeared purely from analyzer upgrades, with no code change. The next such release turns a red gate into a red `main`. Dropping both conditions — `new_code_smells > 0` already covers what matters — needs org-admin access in the SonarCloud UI and is the recommended companion to this PR.
- **Adds roughly 30 seconds to the job.** The scanner polls the compute-engine task; default timeout is 300s.

## Tests

Config-only. Verified `configure-sonar-report-paths.mjs` still rewrites both placeholders with the new property present, and `nx format:check` is clean. The real proof is this PR's own SonarCloud check, which now reflects the gate rather than the upload.

## Links

- [#232](https://github.com/ngworker/lumberjack/pull/232) — cleared the code smells this depends on
- [SonarCloud project dashboard](https://sonarcloud.io/project/overview?id=ngworker_lumberjack)
